### PR TITLE
Added convenience methods for class expression creation

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,10 @@
+use std::env;
+
+pub fn main() {
+    println!("cargo::rustc-check-cfg=cfg(pyi)");
+    if let Ok(flag) = env::var("INCLUDE_PYI") {
+        if flag == "1" || flag.to_lowercase() == "true" {
+            println!("cargo:rustc-cfg=pyi");
+        }
+    }
+}

--- a/pyhornedowl/model/__init__.pyi
+++ b/pyhornedowl/model/__init__.pyi
@@ -6,14 +6,19 @@ class Class:
     first: IRI
     def __init__(self, first: IRI):
         ...
-    ...
 
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """Intersection of two class expressions"""
         ...
 
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """Union of two class expressions"""
+        ...
+
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
+        ...
+    ...
 
 class ObjectIntersectionOf:
     first: typing.List[ClassExpression]
@@ -21,24 +26,17 @@ class ObjectIntersectionOf:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectUnionOf:
     first: typing.List[ClassExpression]
@@ -46,24 +44,17 @@ class ObjectUnionOf:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectComplementOf:
     first: ClassExpression
@@ -71,24 +62,17 @@ class ObjectComplementOf:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectOneOf:
     first: typing.List[Individual]
@@ -96,24 +80,17 @@ class ObjectOneOf:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectSomeValuesFrom:
     ope: ObjectPropertyExpression
@@ -122,24 +99,17 @@ class ObjectSomeValuesFrom:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectAllValuesFrom:
     ope: ObjectPropertyExpression
@@ -148,24 +118,17 @@ class ObjectAllValuesFrom:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectHasValue:
     ope: ObjectPropertyExpression
@@ -174,24 +137,17 @@ class ObjectHasValue:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectHasSelf:
     first: ObjectPropertyExpression
@@ -199,24 +155,17 @@ class ObjectHasSelf:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectMinCardinality:
     n: int
@@ -226,24 +175,17 @@ class ObjectMinCardinality:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectMaxCardinality:
     n: int
@@ -253,24 +195,17 @@ class ObjectMaxCardinality:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class ObjectExactCardinality:
     n: int
@@ -280,24 +215,17 @@ class ObjectExactCardinality:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class DataSomeValuesFrom:
     dp: DataProperty
@@ -306,24 +234,17 @@ class DataSomeValuesFrom:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class DataAllValuesFrom:
     dp: DataProperty
@@ -332,24 +253,17 @@ class DataAllValuesFrom:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class DataHasValue:
     dp: DataProperty
@@ -358,24 +272,17 @@ class DataHasValue:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class DataMinCardinality:
     n: int
@@ -385,24 +292,17 @@ class DataMinCardinality:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class DataMaxCardinality:
     n: int
@@ -412,24 +312,17 @@ class DataMaxCardinality:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class DataExactCardinality:
     n: int
@@ -439,24 +332,17 @@ class DataExactCardinality:
         ...
 
     def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Intersection of two class expressions'''
+        """Intersection of two class expressions"""
         ...
 
     def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Union of two class expressions'''
+        """Union of two class expressions"""
         ...
 
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        '''Complement of a class expression'''
+    def __invert__(self) -> ObjectIntersectionOf:
+        """Complement of a class expression"""
         ...
     ...
-
-    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
-        """
-        Intersection of two class expressions
-        """
-        ...
-
 
 class Datatype:
     first: IRI
@@ -519,11 +405,37 @@ class ObjectProperty:
     first: IRI
     def __init__(self, first: IRI):
         ...
+
+    def some(self, ce: ClassExpression) -> ObjectSomeValuesFrom:
+        """Existentional relationship"""
+        ...
+
+
+    def only(self, ce: ClassExpression) -> ObjectAllValuesFrom:
+        """Universal relationship"""
+        ...
+
+    def __invert__(self) -> ObjectPropertyExpression:
+        """Inverse of object property expression"""
+        ...
     ...
 
 class InverseObjectProperty:
     first: ObjectProperty
     def __init__(self, first: ObjectProperty):
+        ...
+
+    def some(self, ce: ClassExpression) -> ObjectSomeValuesFrom:
+        """Existentional relationship"""
+        ...
+
+
+    def only(self, ce: ClassExpression) -> ObjectAllValuesFrom:
+        """Universal relationship"""
+        ...
+
+    def __invert__(self) -> ObjectPropertyExpression:
+        """Inverse of object property expression"""
         ...
     ...
 

--- a/pyhornedowl/model/__init__.pyi
+++ b/pyhornedowl/model/__init__.pyi
@@ -8,56 +8,215 @@ class Class:
         ...
     ...
 
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
+
 class ObjectIntersectionOf:
     first: typing.List[ClassExpression]
     def __init__(self, first: typing.List[ClassExpression]):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectUnionOf:
     first: typing.List[ClassExpression]
     def __init__(self, first: typing.List[ClassExpression]):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectComplementOf:
     first: ClassExpression
     def __init__(self, first: ClassExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectOneOf:
     first: typing.List[Individual]
     def __init__(self, first: typing.List[Individual]):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectSomeValuesFrom:
     ope: ObjectPropertyExpression
     bce: ClassExpression
     def __init__(self, ope: ObjectPropertyExpression, bce: ClassExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectAllValuesFrom:
     ope: ObjectPropertyExpression
     bce: ClassExpression
     def __init__(self, ope: ObjectPropertyExpression, bce: ClassExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectHasValue:
     ope: ObjectPropertyExpression
     i: Individual
     def __init__(self, ope: ObjectPropertyExpression, i: Individual):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectHasSelf:
     first: ObjectPropertyExpression
     def __init__(self, first: ObjectPropertyExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectMinCardinality:
     n: int
@@ -65,7 +224,26 @@ class ObjectMinCardinality:
     bce: ClassExpression
     def __init__(self, n: int, ope: ObjectPropertyExpression, bce: ClassExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectMaxCardinality:
     n: int
@@ -73,7 +251,26 @@ class ObjectMaxCardinality:
     bce: ClassExpression
     def __init__(self, n: int, ope: ObjectPropertyExpression, bce: ClassExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class ObjectExactCardinality:
     n: int
@@ -81,28 +278,104 @@ class ObjectExactCardinality:
     bce: ClassExpression
     def __init__(self, n: int, ope: ObjectPropertyExpression, bce: ClassExpression):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class DataSomeValuesFrom:
     dp: DataProperty
     dr: DataRange
     def __init__(self, dp: DataProperty, dr: DataRange):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class DataAllValuesFrom:
     dp: DataProperty
     dr: DataRange
     def __init__(self, dp: DataProperty, dr: DataRange):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class DataHasValue:
     dp: DataProperty
     l: Literal
     def __init__(self, dp: DataProperty, l: Literal):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class DataMinCardinality:
     n: int
@@ -110,7 +383,26 @@ class DataMinCardinality:
     dr: DataRange
     def __init__(self, n: int, dp: DataProperty, dr: DataRange):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class DataMaxCardinality:
     n: int
@@ -118,7 +410,26 @@ class DataMaxCardinality:
     dr: DataRange
     def __init__(self, n: int, dp: DataProperty, dr: DataRange):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class DataExactCardinality:
     n: int
@@ -126,7 +437,26 @@ class DataExactCardinality:
     dr: DataRange
     def __init__(self, n: int, dp: DataProperty, dr: DataRange):
         ...
+
+    def __and__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Intersection of two class expressions'''
+        ...
+
+    def __or__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Union of two class expressions'''
+        ...
+
+    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        '''Complement of a class expression'''
+        ...
     ...
+
+    def that(self, ce: ClassExpression) -> ObjectIntersectionOf:
+        """
+        Intersection of two class expressions
+        """
+        ...
+
 
 class Datatype:
     first: IRI

--- a/pyhornedowl/model/__init__.pyi
+++ b/pyhornedowl/model/__init__.pyi
@@ -410,9 +410,28 @@ class ObjectProperty:
         """Existentional relationship"""
         ...
 
-
     def only(self, ce: ClassExpression) -> ObjectAllValuesFrom:
         """Universal relationship"""
+        ...
+
+    def has_value(self, individual: Individual) -> ObjectHasValue:
+        """Existential relationship to an individual"""
+        ...
+
+    def has_self(self) -> ObjectHasSelf:
+        """Individuals with relation to themselves"""
+        ...
+
+    def min(self, n: int, ce: ClassExpression) -> ObjectMinCardinality:
+        """Minimum cardinality relationship"""
+        ...
+
+    def max(self, n: int, ce: ClassExpression) -> ObjectMaxCardinality:
+        """Maximum cardinality relationship"""
+        ...
+
+    def exact(self, n: int, ce: ClassExpression) -> ObjectExactCardinality:
+        """Exact cardinality relationship"""
         ...
 
     def __invert__(self) -> ObjectPropertyExpression:
@@ -429,9 +448,28 @@ class InverseObjectProperty:
         """Existentional relationship"""
         ...
 
-
     def only(self, ce: ClassExpression) -> ObjectAllValuesFrom:
         """Universal relationship"""
+        ...
+
+    def has_value(self, individual: Individual) -> ObjectHasValue:
+        """Existential relationship to an individual"""
+        ...
+
+    def has_self(self) -> ObjectHasSelf:
+        """Individuals with relation to themselves"""
+        ...
+
+    def min(self, n: int, ce: ClassExpression) -> ObjectMinCardinality:
+        """Minimum cardinality relationship"""
+        ...
+
+    def max(self, n: int, ce: ClassExpression) -> ObjectMaxCardinality:
+        """Maximum cardinality relationship"""
+        ...
+
+    def exact(self, n: int, ce: ClassExpression) -> ObjectExactCardinality:
+        """Exact cardinality relationship"""
         ...
 
     def __invert__(self) -> ObjectPropertyExpression:

--- a/src/model.rs
+++ b/src/model.rs
@@ -213,6 +213,7 @@ macro_rules! wrapped_base {
     };
 }
 
+#[cfg(pyi)]
 macro_rules! extensions_pyi {
     (ClassExpression, $v_name:ident) => {
         "
@@ -447,7 +448,7 @@ macro_rules! wrapped_enum {
                         }
                     }
 
-                    #[cfg(debug_assertions)]
+                    #[cfg(pyi)]
                     #[classmethod]
                     fn __pyi__(_: &Bound<'_, PyType>) -> String {
                         let mut res = String::new();
@@ -661,7 +662,7 @@ macro_rules! wrapped {
                     }
                 }
 
-                #[cfg(debug_assertions)]
+                #[cfg(pyi)]
                 #[classmethod]
                 fn __pyi__(_: &Bound<'_, PyType>) -> String {
                     let mut res = String::new();
@@ -746,7 +747,7 @@ macro_rules! wrapped {
                 )
             }
 
-            #[cfg(debug_assertions)]
+            #[cfg(pyi)]
             #[classmethod]
             fn __pyi__(_: &Bound<'_, PyType>) -> String {
                 let mut res = String::new();
@@ -815,7 +816,6 @@ macro_rules! wrapped {
             )*
         }
 
-        #[cfg(debug_assertions)]
         impl ToPyi for $name {
             #[allow(unused_assignments)]
             fn pyi(module: Option<String>) -> String {
@@ -1061,8 +1061,6 @@ for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
     }
 }
 
-
-#[cfg(debug_assertions)]
 trait ToPyi {
     fn pyi(module: Option<String>) -> String;
 }
@@ -1227,9 +1225,9 @@ pub enum Facet {
     LangRange = 11,
 }
 
-#[cfg(debug_assertions)]
 #[pymethods]
 impl Facet {
+    #[cfg(pyi)]
     #[classmethod]
     fn __pyi__(_: &Bound<'_, PyType>) -> String {
         "class Facet:

--- a/src/model.rs
+++ b/src/model.rs
@@ -237,9 +237,28 @@ macro_rules! extensions_pyi {
         \"\"\"Existentional relationship\"\"\"
         ...
 
-
     def only(self, ce: ClassExpression) -> ObjectAllValuesFrom:
         \"\"\"Universal relationship\"\"\"
+        ...
+
+    def has_value(self, individual: Individual) -> ObjectHasValue:
+        \"\"\"Existential relationship to an individual\"\"\"
+        ...
+
+    def has_self(self) -> ObjectHasSelf:
+        \"\"\"Individuals with relation to themselves\"\"\"
+        ...
+
+    def min(self, n: int, ce: ClassExpression) -> ObjectMinCardinality:
+        \"\"\"Minimum cardinality relationship\"\"\"
+        ...
+
+    def max(self, n: int, ce: ClassExpression) -> ObjectMaxCardinality:
+        \"\"\"Maximum cardinality relationship\"\"\"
+        ...
+
+    def exact(self, n: int, ce: ClassExpression) -> ObjectExactCardinality:
+        \"\"\"Exact cardinality relationship\"\"\"
         ...
 
     def __invert__(self) -> ObjectPropertyExpression:
@@ -285,6 +304,45 @@ macro_rules! extensions {
             fn only(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectAllValuesFrom> {
                 let ce: ClassExpression = obj.extract()?;
                 Ok(ObjectAllValuesFrom {
+                    ope: self.clone().into(),
+                    bce: Box::new(ce).into(),
+                })
+            }
+
+            fn has_value(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectHasValue> {
+                let i: Individual = obj.extract()?;
+                Ok(ObjectHasValue{
+                    ope: self.clone().into(),
+                    i
+                })
+            }
+
+            fn has_self(&self) -> PyResult<ObjectHasSelf> {
+                Ok(ObjectHasSelf(self.clone().into()))
+            }
+
+            fn min(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMinCardinality> {
+                let ce: ClassExpression = obj.extract()?;
+                Ok(ObjectMinCardinality {
+                    n,
+                    ope: self.clone().into(),
+                    bce: Box::new(ce).into(),
+                })
+            }
+
+            fn max(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMaxCardinality> {
+                let ce: ClassExpression = obj.extract()?;
+                Ok(ObjectMaxCardinality {
+                    n,
+                    ope: self.clone().into(),
+                    bce: Box::new(ce).into(),
+                })
+            }
+
+            fn exact(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectExactCardinality> {
+                let ce: ClassExpression = obj.extract()?;
+                Ok(ObjectExactCardinality {
+                    n,
                     ope: self.clone().into(),
                     bce: Box::new(ce).into(),
                 })

--- a/src/model.rs
+++ b/src/model.rs
@@ -224,26 +224,37 @@ macro_rules! extensions_pyi {
         \"\"\"Union of two class expressions\"\"\"
         ...
 
-
-    def __invert__(self, ce: ClassExpression) -> ObjectIntersectionOf:
+    def __invert__(self) -> ObjectIntersectionOf:
         \"\"\"Complement of a class expression\"\"\"
         ...
 "
     };
-    ($($_:tt)+) => {""}
+
+    (ObjectPropertyExpression, $v_name:ident) => {
+        "
+    def some(self, ce: ClassExpression) -> ObjectSomeValuesFrom:
+        \"\"\"Existentional relationship\"\"\"
+        ...
+
+
+    def only(self, ce: ClassExpression) -> ObjectAllValuesFrom:
+        \"\"\"Universal relationship\"\"\"
+        ...
+
+    def __invert__(self) -> ObjectPropertyExpression:
+        \"\"\"Inverse of object property expression\"\"\"
+        ...
+"
+    };
+    ($($_:tt)+) => {
+        ""
+    };
 }
 
 macro_rules! extensions {
     (ClassExpression, $v_name:ident) => {
         #[pymethods]
         impl $v_name {
-            /// that(self, ce: ClassExpression) -> ObjectIntersectionOf
-            ///
-            /// Intersection of two class expressions
-            fn that(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-                self.__and__(obj)
-            }
-
             fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
                 let ce: ClassExpression = obj.extract()?;
                 Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
@@ -264,7 +275,7 @@ macro_rules! extensions {
         impl $v_name {
             fn some(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectSomeValuesFrom> {
                 let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectSomeValuesFrom{
+                Ok(ObjectSomeValuesFrom {
                     ope: self.clone().into(),
                     bce: Box::new(ce).into(),
                 })
@@ -272,21 +283,30 @@ macro_rules! extensions {
 
             fn only(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectAllValuesFrom> {
                 let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectAllValuesFrom{
+                Ok(ObjectAllValuesFrom {
                     ope: self.clone().into(),
                     bce: Box::new(ce).into(),
                 })
             }
 
-            fn __invert__(&self) -> InverseObjectProperty {
-                match self {
-                    InverseObjectProperty(i) => i.clone(),
-                    ObjectProperty(i) => InverseObjectProperty(i.clone())
+            fn __invert__(&self) -> ObjectPropertyExpression {
+                let ope: ObjectPropertyExpression = self.clone().into();
+                let inner: ObjectPropertyExpression_Inner = match ope.0 {
+                    ObjectPropertyExpression_Inner::InverseObjectProperty(
+                        InverseObjectProperty(i),
+                    ) => ObjectPropertyExpression_Inner::ObjectProperty(i),
+                    ObjectPropertyExpression_Inner::ObjectProperty(i) => {
+                        ObjectPropertyExpression_Inner::InverseObjectProperty(
+                            InverseObjectProperty(i),
+                        )
                 }
+                };
+
+                ObjectPropertyExpression(inner)
             }
         }
     };
-    ( $ ( $ _: tt) + ) => {}
+    ( $ ( $ _: tt) + ) => {};
 }
 
 macro_rules! wrapped_enum {
@@ -312,7 +332,6 @@ macro_rules! wrapped_enum {
             #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
             pub struct $name([<$name _ Inner>]);
 
-            #[cfg(debug_assertions)]
             impl ToPyi for $name {
                 #[allow(unused_assignments)]
                 fn pyi(module: Option<String>) -> String {
@@ -473,14 +492,11 @@ macro_rules! wrapped_enum {
                 extensions!($name, $v_name_full);
             )?)*
             $($(
-
                 impl From<$v_name_transparent> for $name {
                     fn from(value: $v_name_transparent) -> Self {
                         $name([<$name _ Inner>]::$v_name_transparent(value))
                     }
                 }
-
-                extensions!($name, $v_name_transparent);
             )?)*
 
             impl From<&horned_owl::model::$name<ArcStr>> for $name {
@@ -580,8 +596,8 @@ macro_rules! wrapped_enum {
 }
 
 macro_rules! named {
-    (pub struct $name:ident ( pub $type0:ty $(, pub $type1:ty)?)) => {
-        wrapped!(pub struct $name ( pub $type0 $(, pub $type1)?));
+    (pub struct $name:ident ( pub $type0:ty $(, pub $type1:ty)?) $(extends $super:ty)?) => {
+        wrapped!(pub struct $name ( pub $type0 $(, pub $type1)?) $(extends $super)?);
 
         impl Display for $name {
             fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -698,7 +714,7 @@ macro_rules! wrapped {
         }
 
     };
-    (pub struct $name:ident ( pub $type0:ty $(, pub $type1:ty)?)) => { paste! {
+    (pub struct $name:ident ( pub $type0:ty $(, pub $type1:ty)?) $(extends $sup:ty)?) => { paste! {
 
         #[doc = concat!(
             stringify!($name),
@@ -747,6 +763,7 @@ macro_rules! wrapped {
                     write!(&mut res, ", second: {}", to_py_type::<$type1>(String::new())).unwrap();
                 )?
                 write!(&mut res, "):\n        ...\n").unwrap();
+                $(write!(&mut res, extensions_pyi!($sup, $name)).unwrap();)?
                 write!(&mut res, "    ...\n").unwrap();
 
                 res
@@ -781,6 +798,8 @@ macro_rules! wrapped {
                 )
             }
         }
+
+        $(extensions!($sup, $name);)?
 
         wrapped_base! {$name}
 
@@ -976,11 +995,12 @@ impl FromCompatible<&u32> for u32 {
 
 impl<'a, T: 'a, U> FromCompatible<&'a Option<T>> for Option<U>
     where
-        U: FromCompatible<&'a T> {
+    U: FromCompatible<&'a T>,
+{
     fn from_c(value: &'a Option<T>) -> Self {
         match value {
             None => None,
-            Some(x) => Some(U::from_c(x))
+            Some(x) => Some(U::from_c(x)),
         }
     }
 }
@@ -988,11 +1008,11 @@ impl<'a, T: 'a, U> FromCompatible<&'a Option<T>> for Option<U>
 impl<U, V, S, T> FromCompatible<(S, T)> for (U, V)
     where
         U: FromCompatible<S>,
-        V: FromCompatible<T>
+    V: FromCompatible<T>,
 {
     fn from_c(value: (S, T)) -> Self {
         match value {
-            (s, t) => (U::from_c(s), V::from_c(t))
+            (s, t) => (U::from_c(s), V::from_c(t)),
         }
     }
 }
@@ -1000,11 +1020,11 @@ impl<U, V, S, T> FromCompatible<(S, T)> for (U, V)
 impl<'a, U, V, S, T> FromCompatible<&'a (S, T)> for (U, V)
     where
         U: FromCompatible<&'a S>,
-        V: FromCompatible<&'a T>
+    V: FromCompatible<&'a T>,
 {
     fn from_c(value: &'a (S, T)) -> Self {
         match value {
-            (s, t) => (U::from_c(s), V::from_c(t))
+            (s, t) => (U::from_c(s), V::from_c(t)),
         }
     }
 }
@@ -1287,10 +1307,10 @@ impl From<horned_owl::vocab::Facet> for Facet {
     }
 }
 
-named! { pub struct Class(pub IRI) }
+named! { pub struct Class(pub IRI) extends ClassExpression }
 named! { pub struct AnonymousIndividual(pub StringWrapper) }
 named! { pub struct NamedIndividual(pub IRI) }
-named! { pub struct ObjectProperty(pub IRI) }
+named! { pub struct ObjectProperty(pub IRI) extends ObjectPropertyExpression }
 named! { pub struct Datatype(pub IRI) }
 named! { pub struct DataProperty(pub IRI) }
 

--- a/test/test_class_expression_builder.py
+++ b/test/test_class_expression_builder.py
@@ -1,8 +1,7 @@
 import unittest
 
 from pyhornedowl import PyIndexedOntology
-from pyhornedowl.model import ObjectComplementOf, ObjectIntersectionOf, ObjectUnionOf, InverseObjectProperty, \
-    ObjectSomeValuesFrom
+from pyhornedowl.model import *
 
 
 class ClassExpressionBuilderTestCase(unittest.TestCase):
@@ -60,6 +59,16 @@ class ClassExpressionBuilderTestCase(unittest.TestCase):
 
         expected = ObjectSomeValuesFrom(op, c)
         actual = op.some(c)
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_only(self):
+        o = PyIndexedOntology()
+        c = o.clazz("https://example.com/A")
+        op = o.object_property("https://example.com/op")
+
+        expected = ObjectAllValuesFrom(op, c)
+        actual = op.only(c)
 
         self.assertEqual(expected, actual)
 

--- a/test/test_class_expression_builder.py
+++ b/test/test_class_expression_builder.py
@@ -72,6 +72,55 @@ class ClassExpressionBuilderTestCase(unittest.TestCase):
 
         self.assertEqual(expected, actual)
 
+    def test_ce_min(self):
+        o = PyIndexedOntology()
+        c = o.clazz("https://example.com/A")
+        op = o.object_property("https://example.com/op")
+
+        expected = ObjectMinCardinality(2, op, c)
+        actual = op.min(2, c)
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_max(self):
+        o = PyIndexedOntology()
+        c = o.clazz("https://example.com/A")
+        op = o.object_property("https://example.com/op")
+
+        expected = ObjectMaxCardinality(2, op, c)
+        actual = op.max(2, c)
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_exact(self):
+        o = PyIndexedOntology()
+        c = o.clazz("https://example.com/A")
+        op = o.object_property("https://example.com/op")
+
+        expected = ObjectExactCardinality(2, op, c)
+        actual = op.exact(2, c)
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_has_value(self):
+        o = PyIndexedOntology()
+        op = o.object_property("https://example.com/op")
+        i = o.named_individual("https://example.com/I")
+
+        expected = ObjectHasValue(op, i)
+        actual = op.has_value(i)
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_has_self(self):
+        o = PyIndexedOntology()
+        op = o.object_property("https://example.com/op")
+
+        expected = ObjectHasSelf(op)
+        actual = op.has_self()
+
+        self.assertEqual(expected, actual)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/test/test_class_expression_builder.py
+++ b/test/test_class_expression_builder.py
@@ -1,0 +1,68 @@
+import unittest
+
+from pyhornedowl import PyIndexedOntology
+from pyhornedowl.model import ObjectComplementOf, ObjectIntersectionOf, ObjectUnionOf, InverseObjectProperty, \
+    ObjectSomeValuesFrom
+
+
+class ClassExpressionBuilderTestCase(unittest.TestCase):
+    def test_ce_not(self):
+        o = PyIndexedOntology()
+        c = o.clazz("https://example.com/A")
+
+        expected = ObjectComplementOf(c)
+        actual = ~c
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_not_complex(self):
+        o = PyIndexedOntology()
+        c = ObjectUnionOf([o.clazz("https://example.com/A"), o.clazz("https://example.com/B")])
+
+        expected = ObjectComplementOf(c)
+        actual = ~c
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_and(self):
+        o = PyIndexedOntology()
+        c1 = o.clazz("https://example.com/A")
+        c2 = o.clazz("https://example.com/B")
+
+        expected = ObjectIntersectionOf([c1, c2])
+        actual = c1 & c2
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_or(self):
+        o = PyIndexedOntology()
+        c1 = o.clazz("https://example.com/A")
+        c2 = o.clazz("https://example.com/B")
+
+        expected = ObjectUnionOf([c1, c2])
+        actual = c1 | c2
+
+        self.assertEqual(expected, actual)
+
+    def test_op_not(self):
+        o = PyIndexedOntology()
+        op = o.object_property("https://example.com/op")
+
+        expected = InverseObjectProperty(op)
+        actual = ~op
+
+        self.assertEqual(expected, actual)
+
+    def test_ce_some(self):
+        o = PyIndexedOntology()
+        c = o.clazz("https://example.com/A")
+        op = o.object_property("https://example.com/op")
+
+        expected = ObjectSomeValuesFrom(op, c)
+        actual = op.some(c)
+
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
`ObjectIntersectionOf`, `ObjectUnionOf`, and `ObjectComplementOf` can now also be created using the operators `&`, `|`, and `~`, respectively.