### PR TITLE
Add missing declaration-getting functions

### DIFF
--- a/pyhornedowl/__init__.pyi
+++ b/pyhornedowl/__init__.pyi
@@ -90,7 +90,7 @@ class PyIndexedOntology:
 
     def get_data_properties(self) -> Set[str]:
         """
-        Returns the IRIs of all declared annotation properties in the ontology.
+        Returns the IRIs of all declared data properties in the ontology.
         """
         ...
 

--- a/pyhornedowl/__init__.pyi
+++ b/pyhornedowl/__init__.pyi
@@ -76,6 +76,12 @@ class PyIndexedOntology:
         """
         ...
 
+    def get_datatypes(self) -> Set[str]:
+        """
+        Returns the IRIs of all declared datatypes in the ontology.
+        """
+        ...
+
     def get_object_properties(self) -> Set[str]:
         """
         Returns the IRIs of all declared object properties in the ontology.

--- a/pyhornedowl/__init__.pyi
+++ b/pyhornedowl/__init__.pyi
@@ -82,6 +82,18 @@ class PyIndexedOntology:
         """
         ...
 
+    def get_annotation_properties(self) -> Set[str]:
+        """
+        Returns the IRIs of all declared annotation properties in the ontology.
+        """
+        ...
+
+    def get_data_properties(self) -> Set[str]:
+        """
+        Returns the IRIs of all declared annotation properties in the ontology.
+        """
+        ...
+
     def get_annotation(self, class_iri: str, ann_iri: str, *, class_iri_is_absolute: Optional[bool] = None, ann_iri_is_absolute: Optional[bool]=None) -> Optional[str]:
         """
         Gets the first annotated value for an entity and annotation property.

--- a/pyhornedowl/__init__.pyi
+++ b/pyhornedowl/__init__.pyi
@@ -94,6 +94,12 @@ class PyIndexedOntology:
         """
         ...
 
+    def get_named_individuals(self) -> Set[str]:
+        """
+        Returns the IRIs of all declared named individuals in the ontology.
+        """
+        ...
+
     def get_annotation(self, class_iri: str, ann_iri: str, *, class_iri_is_absolute: Optional[bool] = None, ann_iri_is_absolute: Optional[bool]=None) -> Optional[str]:
         """
         Gets the first annotated value for an entity and annotation property.

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -463,7 +463,7 @@ impl PyIndexedOntology {
 
     /// get_annotation_properties(self) -> Set[str]
     ///
-    /// Returns the IRIs of all declared object properties in the ontology.
+    /// Returns the IRIs of all declared annotation properties in the ontology.
     pub fn get_annotation_properties(&mut self) -> PyResult<HashSet<String>> {
         //Get the DeclareAnnotationProperty axioms
         let annotation_properties = if let Some(ref mut component_index) = &mut self.component_index {

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -465,7 +465,7 @@ impl PyIndexedOntology {
     ///
     /// Returns the IRIs of all declared annotation properties in the ontology.
     pub fn get_annotation_properties(&mut self) -> PyResult<HashSet<String>> {
-        //Get the DeclareAnnotationProperty axioms
+        // Get the DeclareAnnotationProperty axioms
         let annotation_properties = if let Some(ref mut component_index) = &mut self.component_index {
             Box::new(component_index.component_for_kind(ComponentKind::DeclareAnnotationProperty))
                 as Box<dyn Iterator<Item = &AnnotatedComponent<ArcStr>>>
@@ -486,7 +486,7 @@ impl PyIndexedOntology {
     ///
     /// Returns the IRIs of all declared data properties in the ontology.
     pub fn get_data_properties(&mut self) -> PyResult<HashSet<String>> {
-        //Get the DeclareDataProperty axioms
+        // Get the DeclareDataProperty axioms
         let data_properties = if let Some(ref mut component_index) = &mut self.component_index {
             Box::new(component_index.component_for_kind(ComponentKind::DeclareDataProperty))
                 as Box<dyn Iterator<Item = &AnnotatedComponent<ArcStr>>>
@@ -501,6 +501,27 @@ impl PyIndexedOntology {
             })
             .collect();
         Ok(data_properties)
+    }
+
+    /// get_named_individuals(self) -> Set[str]
+    ///
+    /// Returns the IRIs of all declared named individuals in the ontology.
+    pub fn get_named_individuals(&mut self) -> PyResult<HashSet<String>> {
+        // Get the DeclareNamedIndividual axioms
+        let named_individuals = if let Some(ref mut component_index) = &mut self.component_index {
+            Box::new(component_index.component_for_kind(ComponentKind::DeclareNamedIndividual))
+                as Box<dyn Iterator<Item = &AnnotatedComponent<ArcStr>>>
+        } else {
+            Box::new((&self.set_index).into_iter())
+        };
+
+        let named_individuals: HashSet<String> = named_individuals
+            .filter_map(|aax| match aax.clone().component {
+                Component::DeclareNamedIndividual(dop) => Some(dop.0 .0.to_string()),
+                _ => None,
+            })
+            .collect();
+        Ok(named_individuals)
     }
 
     /// get_annotation(self, class_iri: str, ann_iri: str, *, class_iri_is_absolute: Optional[bool] = None, ann_iri_is_absolute: Optional[bool]=None) -> Optional[str]

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -461,6 +461,48 @@ impl PyIndexedOntology {
         Ok(object_properties)
     }
 
+    /// get_annotation_properties(self) -> Set[str]
+    ///
+    /// Returns the IRIs of all declared object properties in the ontology.
+    pub fn get_annotation_properties(&mut self) -> PyResult<HashSet<String>> {
+        //Get the DeclareAnnotationProperty axioms
+        let annotation_properties = if let Some(ref mut component_index) = &mut self.component_index {
+            Box::new(component_index.component_for_kind(ComponentKind::DeclareAnnotationProperty))
+                as Box<dyn Iterator<Item = &AnnotatedComponent<ArcStr>>>
+        } else {
+            Box::new((&self.set_index).into_iter())
+        };
+
+        let annotation_properties: HashSet<String> = annotation_properties
+            .filter_map(|aax| match aax.clone().component {
+                Component::DeclareAnnotationProperty(dop) => Some(dop.0 .0.to_string()),
+                _ => None,
+            })
+            .collect();
+        Ok(annotation_properties)
+    }
+
+    /// get_data_properties(self) -> Set[str]
+    ///
+    /// Returns the IRIs of all declared data properties in the ontology.
+    pub fn get_data_properties(&mut self) -> PyResult<HashSet<String>> {
+        //Get the DeclareDataProperty axioms
+        let data_properties = if let Some(ref mut component_index) = &mut self.component_index {
+            Box::new(component_index.component_for_kind(ComponentKind::DeclareDataProperty))
+                as Box<dyn Iterator<Item = &AnnotatedComponent<ArcStr>>>
+        } else {
+            Box::new((&self.set_index).into_iter())
+        };
+
+        let data_properties: HashSet<String> = data_properties
+            .filter_map(|aax| match aax.clone().component {
+                Component::DeclareDataProperty(dop) => Some(dop.0 .0.to_string()),
+                _ => None,
+            })
+            .collect();
+        Ok(data_properties)
+    }
+
     /// get_annotation(self, class_iri: str, ann_iri: str, *, class_iri_is_absolute: Optional[bool] = None, ann_iri_is_absolute: Optional[bool]=None) -> Optional[str]
     ///
     /// Gets the first annotated value for an entity and annotation property.

--- a/test/test_entity_query.py
+++ b/test/test_entity_query.py
@@ -1,0 +1,79 @@
+import unittest
+
+import pyhornedowl
+from pyhornedowl.model import *
+
+from test_base import RDFS_LABEL
+
+
+class EntityQueryTestCase(unittest.TestCase):
+    """Tests for the ontology."""
+
+    def setUp(self) -> None:
+        """Set up the test case with an ontology."""
+        components = [
+            DeclareClass(Class(IRI.parse("https://example.com/A"))),
+            DeclareClass(Class(IRI.parse("https://example.com/B"))),
+            DeclareClass(Class(IRI.parse("https://example.com/C"))),
+            DeclareClass(Class(IRI.parse("https://example.com/D"))),
+            DeclareAnnotationProperty(AnnotationProperty(IRI.parse(RDFS_LABEL))),
+            DeclareObjectProperty(ObjectProperty(IRI.parse("https://example.com/E"))),
+            DeclareDataProperty(DataProperty(IRI.parse("https://example.com/F"))),
+            DeclareNamedIndividual(NamedIndividual(IRI.parse("https://example.com/G"))),
+            DeclareDatatype(Datatype(IRI.parse("https://example.com/H"))),
+        ]
+
+        onto = pyhornedowl.PyIndexedOntology()
+        onto.prefix_mapping.add_default_prefix_names()
+        onto.prefix_mapping.add_prefix("", "https://example.com/")
+
+        for component in components:
+            onto.add_component(component)
+
+        self.o = onto
+
+    def test_get_object_properties(self) -> None:
+        """Test getting object properties."""
+        self.assertEqual(
+            {"https://example.com/E"},
+            self.o.get_object_properties(),
+        )
+
+    def test_get_data_properties(self) -> None:
+        """Test getting data properties."""
+        self.assertEqual(
+            {"https://example.com/F"},
+            self.o.get_data_properties(),
+        )
+
+    def test_get_annotation_properties(self) -> None:
+        """Test getting annotation properties."""
+        self.assertEqual(
+            {RDFS_LABEL},
+            self.o.get_annotation_properties(),
+        )
+
+    def test_get_classes(self) -> None:
+        """Test getting classes."""
+        self.assertEqual(
+            {f"https://example.com/{x}" for x in "ABCD"},
+            self.o.get_classes(),
+        )
+
+    def test_named_individuals(self) -> None:
+        """Test getting named individuals."""
+        self.assertEqual(
+            {"https://example.com/G"},
+            self.o.get_named_individuals(),
+        )
+
+    def test_datatypes(self) -> None:
+        """Test getting datatypes."""
+        self.assertEqual(
+            {"https://example.com/H"},
+            self.o.get_datatypes(),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -21,6 +21,7 @@ class OntologyTestCase(unittest.TestCase):
             DeclareAnnotationProperty(AnnotationProperty(IRI.parse(RDFS_LABEL))),
             DeclareObjectProperty(ObjectProperty(IRI.parse("https://example.com/E"))),
             DeclareDataProperty(DataProperty(IRI.parse("https://example.com/F"))),
+            DeclareNamedIndividual(NamedIndividual(IRI.parse("https://example.com/G"))),
         ]
 
         onto = pyhornedowl.PyIndexedOntology()
@@ -58,6 +59,13 @@ class OntologyTestCase(unittest.TestCase):
         self.assertEqual(
             {f"https://example.com/{x}" for x in "ABCD"},
             self.o.get_classes(),
+        )
+
+    def test_named_individuals(self) -> None:
+        """Test getting named individuals."""
+        self.assertEqual(
+            {"https://example.com/G"},
+            self.o.get_named_individuals(),
         )
 
 

--- a/test/test_ontology.py
+++ b/test/test_ontology.py
@@ -1,0 +1,65 @@
+"""Tests for the ontology."""
+
+import unittest
+
+import pyhornedowl
+from pyhornedowl.model import *
+
+from test_base import RDFS_LABEL
+
+
+class OntologyTestCase(unittest.TestCase):
+    """Tests for the ontology."""
+
+    def setUp(self) -> None:
+        """Set up the test case with an ontology."""
+        components = [
+            DeclareClass(Class(IRI.parse("https://example.com/A"))),
+            DeclareClass(Class(IRI.parse("https://example.com/B"))),
+            DeclareClass(Class(IRI.parse("https://example.com/C"))),
+            DeclareClass(Class(IRI.parse("https://example.com/D"))),
+            DeclareAnnotationProperty(AnnotationProperty(IRI.parse(RDFS_LABEL))),
+            DeclareObjectProperty(ObjectProperty(IRI.parse("https://example.com/E"))),
+            DeclareDataProperty(DataProperty(IRI.parse("https://example.com/F"))),
+        ]
+
+        onto = pyhornedowl.PyIndexedOntology()
+        onto.prefix_mapping.add_default_prefix_names()
+        onto.prefix_mapping.add_prefix("", "https://example.com/")
+
+        for component in components:
+            onto.add_component(component)
+
+        self.o = onto
+
+    def test_get_object_properties(self) -> None:
+        """Test getting object properties."""
+        self.assertEqual(
+            {"https://example.com/E"},
+            self.o.get_object_properties(),
+        )
+
+    def test_get_data_properties(self) -> None:
+        """Test getting data properties."""
+        self.assertEqual(
+            {"https://example.com/F"},
+            self.o.get_data_properties(),
+        )
+
+    def test_get_annotation_properties(self) -> None:
+        """Test getting annotation properties."""
+        self.assertEqual(
+            {RDFS_LABEL},
+            self.o.get_annotation_properties(),
+        )
+
+    def test_get_classes(self) -> None:
+        """Test getting classes."""
+        self.assertEqual(
+            {f"https://example.com/{x}" for x in "ABCD"},
+            self.o.get_classes(),
+        )
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Currently, there's a function `get_object_properties` that gets a list of declared object properties. This PR adds functions corresponding to the other types of declarations:

1. annotation properties
2. data properties
3. named individuals

This PR also adds tests for all three new functions, as well as one for the pre-existing, untested `get_object_properties`.

Since I don't have rights to run CI without approval here, I also made a corresponding internal PR in my fork to demonstrate this works: https://github.com/cthoyt/py-horned-owl/pull/1