### PR TITLE
Drop python 3.8 and 3.9 support

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -265,7 +265,7 @@ jobs:
     needs: linux
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "maturin"
 [project]
 dynamic = ["version"]
 name = "py-horned-owl"
-requires-python = ">=3.7"
+requires-python = ">=3.10"
 license = {text = "LGPL-3.0-or-later"}
 classifiers = [
     "Programming Language :: Rust",


### PR DESCRIPTION
Python 3.8 and 3.9 have reached their end of life.