### PR TITLE
Fix: make targets fail when a .venv already exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all dev mdev model docs tests .venv
+.PHONY: all dev mdev model docs tests
 
 all: lib pyi
 


### PR DESCRIPTION
`.venv` is declared `.PHONY`, so make runs its recipe unconditionally and `uv venv` fails on any checkout that already has one:

```
$ make dev
uv venv
error: Failed to create virtual environment
  Caused by: A virtual environment already exists at: .venv

hint: Use the `--clear` flag or set `UV_VENV_CLEAR=1` to replace the existing virtual environment
make: *** [.venv] Error 2
```

That takes out every target depending on it — `dev`, `mdev`, `pyi`, `model`, `docs`, `tests` — so the documented build works only on a fresh clone. I hit it working on #67 and fell back to calling `maturin develop` and the scripts directly.

The declaration dates from 8658cf3, which renamed the target from `venv` to `.venv`. Under the old name nothing on disk ever matched, so the recipe always ran and phony was accurate. Matching the real directory is what makes the existence check work, and phony is what disables it.

Dropping `.venv` from `.PHONY` restores the check: the recipe runs when `.venv` is absent, and is skipped when it is present.

Verified both ways — `make dev` now completes on a checkout with an existing `.venv` (it failed at the first step before), and `make -n .venv` in an empty directory still runs `uv venv` + `uv sync`. The regenerated model and stubs come out byte-identical.

**One thing you may want on top of this:** with the existence check restored, the venv is never re-synced after a dependency change, since make only checks that the directory exists. If that matters, the target could become

```make
.venv: pyproject.toml uv.lock
	uv venv --allow-existing
	uv sync --all-groups --no-install-project
	@touch .venv
```

which re-syncs when the manifests change. I left it out as a separate judgement call — happy to fold it in if you prefer.
