### PR TITLE
Make cargo fmt --check pass, and enforce it plus generated-file freshness in CI

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -144,34 +144,6 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
-  generated:
-    name: Generated files up to date
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
-      - name: Check formatting
-        run: |
-          rustup component add rustfmt
-          cargo fmt --check
-      # The generators are invoked directly rather than through the Makefile:
-      # its `docs` target extracts rustdoc JSON from a local horned-owl
-      # checkout using a nightly toolchain, which CI has neither of, so
-      # src/doc.rs stays hand-regenerated.
-      - name: Regenerate the model and the type stubs
-        run: |
-          uv venv --allow-existing
-          uv sync --all-groups --no-install-project
-          .venv/bin/python scripts/build_model.py
-          uv run --with maturin maturin develop
-          .venv/bin/python scripts/gen_pyi.py
-      - name: Fail if anything regenerated differently
-        run: |
-          git diff --exit-code || {
-            echo "::error::Generated files are out of date. Run 'make dev' and commit the result."
-            exit 1
-          }
-
   sdist:
     runs-on: ubuntu-latest
     steps:
@@ -191,7 +163,7 @@ jobs:
     name: Release
     runs-on: ubuntu-latest
     if: ${{ startsWith(github.ref, 'refs/tags/') || github.event_name == 'workflow_dispatch' }}
-    needs: [linux, musllinux, windows, macos, sdist]
+    needs: [linux, musllinux, windows, macos, sdist, hygiene, tests]
     permissions:
       # Use to sign the release artifacts
       id-token: write
@@ -211,6 +183,36 @@ jobs:
       - name: Publish to PyPI
         if: ${{ startsWith(github.ref, 'refs/tags/') }}
         run: uv publish --trusted-publishing always 'wheels-*/*'
+
+  hygiene:
+    name: Check formatting and codegen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - name: Check formatting
+        run: |
+          rustup component add rustfmt
+          cargo fmt --check
+      # The generators are invoked directly rather than through the Makefile:
+      # its `docs` target extracts rustdoc JSON from a local horned-owl
+      # checkout using a nightly toolchain, which CI has neither of, so
+      # src/doc.rs stays hand-regenerated.
+      - name: Regenerate the model and the type stubs
+        run: |
+          uv venv --allow-existing
+          uv sync --frozen --all-groups --no-install-project
+          .venv/bin/python scripts/build_model.py
+          uv run --frozen --with maturin maturin develop
+          .venv/bin/python scripts/gen_pyi.py
+      - name: Fail if anything regenerated differently
+        run: |
+          changed=$(git status --porcelain -- src pyhornedowl)
+          if [ -n "$changed" ]; then
+            echo "$changed"
+            echo "::error::Generated files are out of date. Run 'make dev' and commit the result."
+            exit 1
+          fi
 
   build-docs:
     needs: linux

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -144,6 +144,34 @@ jobs:
           name: wheels-macos-${{ matrix.platform.target }}
           path: dist
 
+  generated:
+    name: Generated files up to date
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - uses: astral-sh/setup-uv@v7
+      - name: Check formatting
+        run: |
+          rustup component add rustfmt
+          cargo fmt --check
+      # The generators are invoked directly rather than through the Makefile:
+      # its `docs` target extracts rustdoc JSON from a local horned-owl
+      # checkout using a nightly toolchain, which CI has neither of, so
+      # src/doc.rs stays hand-regenerated.
+      - name: Regenerate the model and the type stubs
+        run: |
+          uv venv --allow-existing
+          uv sync --all-groups --no-install-project
+          .venv/bin/python scripts/build_model.py
+          uv run --with maturin maturin develop
+          .venv/bin/python scripts/gen_pyi.py
+      - name: Fail if anything regenerated differently
+        run: |
+          git diff --exit-code || {
+            echo "::error::Generated files are out of date. Run 'make dev' and commit the result."
+            exit 1
+          }
+
   sdist:
     runs-on: ubuntu-latest
     steps:

--- a/scripts/build_model.py
+++ b/scripts/build_model.py
@@ -1,5 +1,8 @@
 import json
 import os
+import re
+import shutil
+import subprocess
 from typing import Optional, Literal
 
 from jinja2 import Environment, select_autoescape, FileSystemLoader, pass_context
@@ -165,10 +168,39 @@ def build_from_templates(lang: Literal["rs", "pyi"]):
 
     return "".join(out)
 
-def main():
+def crate_edition() -> str:
+    """The Rust edition from Cargo.toml, which rustfmt has to be told."""
+    with open(os.path.join(REPO_ROOT, "Cargo.toml")) as f:
+        match = re.search(r'^edition\s*=\s*"(\d+)"', f.read(), re.MULTILINE)
 
-    with open(os.path.join(REPO_ROOT, "src", "model_generated.rs"), "w") as f:
+    return match.group(1) if match else "2021"
+
+
+def rustfmt(path: str):
+    """Format generated Rust in place.
+
+    The templates cannot reasonably keep to a line width of their own: how long
+    an emitted line is depends on the name of the model class it is emitted
+    for. So the generator formats its own output, the way codegen for any other
+    language would, and the templates stay readable.
+    """
+    if shutil.which("rustfmt") is None:
+        raise SystemExit(
+            "rustfmt is needed to format the generated model but was not found. "
+            "It ships with rustup's default toolchain; otherwise "
+            "`rustup component add rustfmt`."
+        )
+
+    subprocess.run(["rustfmt", "--edition", crate_edition(), path], check=True)
+
+
+def main():
+    generated = os.path.join(REPO_ROOT, "src", "model_generated.rs")
+
+    with open(generated, "w") as f:
         f.write(build_from_templates("rs"))
+
+    rustfmt(generated)
 
 
 if __name__ == "__main__":

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -214,9 +214,7 @@ fn open_ontology_from_string(
     let input_format = serialization
         .map(parse_serialization)
         .transpose()?
-        .or_else(|| {
-            horned_owl::io::detect_format(ontology.as_bytes()).map(to_input_format)
-        });
+        .or_else(|| horned_owl::io::detect_format(ontology.as_bytes()).map(to_input_format));
 
     let config = default_parser_config(input_format);
 

--- a/src/model_generated.rs
+++ b/src/model_generated.rs
@@ -1,13 +1,17 @@
 #![allow(clippy::all)]
 
-use std::{borrow::Borrow, collections::{BTreeSet,hash_map::DefaultHasher}, sync::Arc};
 use std::fmt::Display;
 use std::hash::{Hash, Hasher};
+use std::{
+    borrow::Borrow,
+    collections::{hash_map::DefaultHasher, BTreeSet},
+    sync::Arc,
+};
 
 use horned_owl::io::ofn::writer::AsFunctional;
 
 use horned_owl::model::ArcStr;
-use pyo3::{exceptions::PyKeyError, prelude::*, PyAny, types::PyType};
+use pyo3::{exceptions::PyKeyError, prelude::*, types::PyType, PyAny};
 
 use crate::wrappers::*;
 
@@ -37,9 +41,8 @@ impl FromCompatible<IRI> for horned_owl::model::IRI<Arc<str>> {
     }
 }
 
-
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[pyclass(module = "pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 pub struct IRI(horned_owl::model::IRI<ArcStr>);
 
 impl From<IRI> for horned_owl::model::IRI<ArcStr> {
@@ -139,10 +142,9 @@ impl FromCompatible<horned_owl::vocab::Facet> for Facet {
     }
 }
 
-
 #[doc = doc!(Facet)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-#[pyclass(module = "pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 pub enum Facet {
     Length = 1,
     MinLength = 2,
@@ -175,7 +177,7 @@ impl Facet {
     FractionDigits: Facet
     LangRange: Facet
 "
-            .to_owned()
+        .to_owned()
     }
 
     fn __hash__(&self) -> u64 {
@@ -265,11 +267,10 @@ impl From<horned_owl::vocab::Facet> for Facet {
     }
 }
 
-
 /************ Annotations *******************/
 
 impl FromCompatible<&BTreeSet<horned_owl::model::Annotation<Arc<str>>>>
-for BTreeSetWrap<Annotation>
+    for BTreeSetWrap<Annotation>
 {
     fn from_c(value: &BTreeSet<horned_owl::model::Annotation<Arc<str>>>) -> Self {
         BTreeSetWrap::<Annotation>::from(value)
@@ -277,7 +278,7 @@ for BTreeSetWrap<Annotation>
 }
 
 impl FromCompatible<&BTreeSetWrap<Annotation>>
-for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
+    for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
 {
     fn from_c(value: &BTreeSetWrap<Annotation>) -> Self {
         BTreeSet::<horned_owl::model::Annotation<Arc<str>>>::from(value)
@@ -285,7 +286,7 @@ for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
 }
 
 impl FromCompatible<BTreeSet<horned_owl::model::Annotation<Arc<str>>>>
-for BTreeSetWrap<Annotation>
+    for BTreeSetWrap<Annotation>
 {
     fn from_c(value: BTreeSet<horned_owl::model::Annotation<Arc<str>>>) -> Self {
         FromCompatible::from_c(value.borrow())
@@ -293,7 +294,7 @@ for BTreeSetWrap<Annotation>
 }
 
 impl FromCompatible<BTreeSetWrap<Annotation>>
-for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
+    for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
 {
     fn from_c(value: BTreeSetWrap<Annotation>) -> Self {
         FromCompatible::from_c(value.borrow())
@@ -305,26 +306,24 @@ for BTreeSet<horned_owl::model::Annotation<Arc<str>>>
     "\n\n",
     doc!(Class)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Class (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct Class(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl Class {
     #[new]
-    fn new(first: IRI,) -> Self {
-        Class (first,)
+    fn new(first: IRI) -> Self {
+        Class(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -336,7 +335,6 @@ impl Class {
     fn __eq__(&self, other: &Self) -> bool {
         self == other
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -360,22 +358,15 @@ impl Class {
 
 impl From<&horned_owl::model::Class<ArcStr>> for Class {
     fn from(value: &horned_owl::model::Class<ArcStr>) -> Self {
-
-        Class (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        Class(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&Class> for horned_owl::model::Class<ArcStr> {
     fn from(value: &Class) -> Self {
-        horned_owl::model::Class::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::Class::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for Class ****************/
 impl FromCompatible<horned_owl::model::Class<ArcStr>> for Class {
@@ -505,61 +496,59 @@ impl FromCompatible<&Vec<horned_owl::model::Class<ArcStr>>> for VecWrap<Class> {
         VecWrap::<Class>::from(value)
     }
 }
-    /******** EXTENSION "named" for Class ********/
-    impl Display for Class {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0.0)
-        }
+/******** EXTENSION "named" for Class ********/
+impl Display for Class {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
+    }
+}
+
+#[pymethods]
+impl Class {
+    fn __str__(&self) -> String {
+        self.to_string()
+    }
+}
+/******** EXTENSION "class-expression" for Class ********/
+#[pymethods]
+impl Class {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    #[pymethods]
-    impl Class {
-        fn __str__(&self) -> String {
-            self.to_string()
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
-    /******** EXTENSION "class-expression" for Class ********/
-    #[pymethods]
-    impl Class {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
 
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
     }
+}
 #[doc = concat!(
     "AnonymousIndividual(first: str,)",
     "\n\n",
     doc!(AnonymousIndividual)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AnonymousIndividual (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct AnonymousIndividual(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub StringWrapper,
 );
 
 #[pymethods]
 impl AnonymousIndividual {
     #[new]
-    fn new(first: StringWrapper,) -> Self {
-        AnonymousIndividual (first,)
+    fn new(first: StringWrapper) -> Self {
+        AnonymousIndividual(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -571,7 +560,6 @@ impl AnonymousIndividual {
     fn __eq__(&self, other: &Self) -> bool {
         self == other
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -595,22 +583,15 @@ impl AnonymousIndividual {
 
 impl From<&horned_owl::model::AnonymousIndividual<ArcStr>> for AnonymousIndividual {
     fn from(value: &horned_owl::model::AnonymousIndividual<ArcStr>) -> Self {
-
-        AnonymousIndividual (
-    IntoCompatible::<StringWrapper>::into_c(&value.0),
-        )
+        AnonymousIndividual(IntoCompatible::<StringWrapper>::into_c(&value.0))
     }
 }
 
 impl From<&AnonymousIndividual> for horned_owl::model::AnonymousIndividual<ArcStr> {
     fn from(value: &AnonymousIndividual) -> Self {
-        horned_owl::model::AnonymousIndividual::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::AnonymousIndividual::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for AnonymousIndividual ****************/
 impl FromCompatible<horned_owl::model::AnonymousIndividual<ArcStr>> for AnonymousIndividual {
@@ -700,84 +681,98 @@ impl From<&Vec<horned_owl::model::AnonymousIndividual<ArcStr>>> for VecWrap<Anon
     }
 }
 
-impl FromCompatible<&BoxWrap<AnonymousIndividual>> for Box<horned_owl::model::AnonymousIndividual<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnonymousIndividual>>
+    for Box<horned_owl::model::AnonymousIndividual<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnonymousIndividual>) -> Self {
         Box::<horned_owl::model::AnonymousIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnonymousIndividual<ArcStr>>> for BoxWrap<AnonymousIndividual> {
+impl FromCompatible<&Box<horned_owl::model::AnonymousIndividual<ArcStr>>>
+    for BoxWrap<AnonymousIndividual>
+{
     fn from_c(value: &Box<horned_owl::model::AnonymousIndividual<ArcStr>>) -> Self {
         BoxWrap::<AnonymousIndividual>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnonymousIndividual>> for Box<horned_owl::model::AnonymousIndividual<ArcStr>> {
+impl FromCompatible<BoxWrap<AnonymousIndividual>>
+    for Box<horned_owl::model::AnonymousIndividual<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnonymousIndividual>) -> Self {
         Box::<horned_owl::model::AnonymousIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnonymousIndividual<ArcStr>>> for BoxWrap<AnonymousIndividual> {
+impl FromCompatible<Box<horned_owl::model::AnonymousIndividual<ArcStr>>>
+    for BoxWrap<AnonymousIndividual>
+{
     fn from_c(value: Box<horned_owl::model::AnonymousIndividual<ArcStr>>) -> Self {
         BoxWrap::<AnonymousIndividual>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnonymousIndividual>> for Vec<horned_owl::model::AnonymousIndividual<ArcStr>> {
+impl FromCompatible<VecWrap<AnonymousIndividual>>
+    for Vec<horned_owl::model::AnonymousIndividual<ArcStr>>
+{
     fn from_c(value: VecWrap<AnonymousIndividual>) -> Self {
         Vec::<horned_owl::model::AnonymousIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnonymousIndividual<ArcStr>>> for VecWrap<AnonymousIndividual> {
+impl FromCompatible<Vec<horned_owl::model::AnonymousIndividual<ArcStr>>>
+    for VecWrap<AnonymousIndividual>
+{
     fn from_c(value: Vec<horned_owl::model::AnonymousIndividual<ArcStr>>) -> Self {
         VecWrap::<AnonymousIndividual>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnonymousIndividual>> for Vec<horned_owl::model::AnonymousIndividual<ArcStr>> {
+impl FromCompatible<&VecWrap<AnonymousIndividual>>
+    for Vec<horned_owl::model::AnonymousIndividual<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnonymousIndividual>) -> Self {
         Vec::<horned_owl::model::AnonymousIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnonymousIndividual<ArcStr>>> for VecWrap<AnonymousIndividual> {
+impl FromCompatible<&Vec<horned_owl::model::AnonymousIndividual<ArcStr>>>
+    for VecWrap<AnonymousIndividual>
+{
     fn from_c(value: &Vec<horned_owl::model::AnonymousIndividual<ArcStr>>) -> Self {
         VecWrap::<AnonymousIndividual>::from(value)
     }
 }
-    /******** EXTENSION "named" for AnonymousIndividual ********/
-    impl Display for AnonymousIndividual {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0.0)
-        }
+/******** EXTENSION "named" for AnonymousIndividual ********/
+impl Display for AnonymousIndividual {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
     }
+}
 
-    #[pymethods]
-    impl AnonymousIndividual {
-        fn __str__(&self) -> String {
-            self.to_string()
-        }
+#[pymethods]
+impl AnonymousIndividual {
+    fn __str__(&self) -> String {
+        self.to_string()
     }
+}
 #[doc = concat!(
     "NamedIndividual(first: IRI,)",
     "\n\n",
     doc!(NamedIndividual)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct NamedIndividual (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct NamedIndividual(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl NamedIndividual {
     #[new]
-    fn new(first: IRI,) -> Self {
-        NamedIndividual (first,)
+    fn new(first: IRI) -> Self {
+        NamedIndividual(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -789,7 +784,6 @@ impl NamedIndividual {
     fn __eq__(&self, other: &Self) -> bool {
         self == other
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -813,22 +807,15 @@ impl NamedIndividual {
 
 impl From<&horned_owl::model::NamedIndividual<ArcStr>> for NamedIndividual {
     fn from(value: &horned_owl::model::NamedIndividual<ArcStr>) -> Self {
-
-        NamedIndividual (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        NamedIndividual(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&NamedIndividual> for horned_owl::model::NamedIndividual<ArcStr> {
     fn from(value: &NamedIndividual) -> Self {
-        horned_owl::model::NamedIndividual::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::NamedIndividual::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for NamedIndividual ****************/
 impl FromCompatible<horned_owl::model::NamedIndividual<ArcStr>> for NamedIndividual {
@@ -958,44 +945,42 @@ impl FromCompatible<&Vec<horned_owl::model::NamedIndividual<ArcStr>>> for VecWra
         VecWrap::<NamedIndividual>::from(value)
     }
 }
-    /******** EXTENSION "named" for NamedIndividual ********/
-    impl Display for NamedIndividual {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0.0)
-        }
+/******** EXTENSION "named" for NamedIndividual ********/
+impl Display for NamedIndividual {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
     }
+}
 
-    #[pymethods]
-    impl NamedIndividual {
-        fn __str__(&self) -> String {
-            self.to_string()
-        }
+#[pymethods]
+impl NamedIndividual {
+    fn __str__(&self) -> String {
+        self.to_string()
     }
+}
 #[doc = concat!(
     "ObjectProperty(first: IRI,)",
     "\n\n",
     doc!(ObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct ObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl ObjectProperty {
     #[new]
-    fn new(first: IRI,) -> Self {
-        ObjectProperty (first,)
+    fn new(first: IRI) -> Self {
+        ObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -1007,7 +992,6 @@ impl ObjectProperty {
     fn __eq__(&self, other: &Self) -> bool {
         self == other
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -1031,22 +1015,15 @@ impl ObjectProperty {
 
 impl From<&horned_owl::model::ObjectProperty<ArcStr>> for ObjectProperty {
     fn from(value: &horned_owl::model::ObjectProperty<ArcStr>) -> Self {
-
-        ObjectProperty (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        ObjectProperty(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&ObjectProperty> for horned_owl::model::ObjectProperty<ArcStr> {
     fn from(value: &ObjectProperty) -> Self {
-        horned_owl::model::ObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::ObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for ObjectProperty ****************/
 impl FromCompatible<horned_owl::model::ObjectProperty<ArcStr>> for ObjectProperty {
@@ -1176,118 +1153,114 @@ impl FromCompatible<&Vec<horned_owl::model::ObjectProperty<ArcStr>>> for VecWrap
         VecWrap::<ObjectProperty>::from(value)
     }
 }
-    /******** EXTENSION "named" for ObjectProperty ********/
-    impl Display for ObjectProperty {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0.0)
-        }
+/******** EXTENSION "named" for ObjectProperty ********/
+impl Display for ObjectProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
+    }
+}
+
+#[pymethods]
+impl ObjectProperty {
+    fn __str__(&self) -> String {
+        self.to_string()
+    }
+}
+/******** EXTENSION "object-property-expression" for ObjectProperty ********/
+#[pymethods]
+impl ObjectProperty {
+    fn some(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectSomeValuesFrom> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectSomeValuesFrom {
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
     }
 
-    #[pymethods]
-    impl ObjectProperty {
-        fn __str__(&self) -> String {
-            self.to_string()
-        }
+    fn only(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectAllValuesFrom> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectAllValuesFrom {
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
     }
-    /******** EXTENSION "object-property-expression" for ObjectProperty ********/
-       #[pymethods]
-        impl ObjectProperty {
-            fn some(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectSomeValuesFrom> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectSomeValuesFrom {
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
 
-            fn only(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectAllValuesFrom> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectAllValuesFrom {
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
+    fn has_value(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectHasValue> {
+        let i: Individual = obj.extract()?;
+        Ok(ObjectHasValue {
+            ope: self.clone().into(),
+            i,
+        })
+    }
 
-            fn has_value(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectHasValue> {
-                let i: Individual = obj.extract()?;
-                Ok(ObjectHasValue{
-                    ope: self.clone().into(),
-                    i
-                })
-            }
+    fn has_self(&self) -> PyResult<ObjectHasSelf> {
+        Ok(ObjectHasSelf(self.clone().into()))
+    }
 
-            fn has_self(&self) -> PyResult<ObjectHasSelf> {
-                Ok(ObjectHasSelf(self.clone().into()))
-            }
+    fn min(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMinCardinality> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectMinCardinality {
+            n,
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
+    }
 
-            fn min(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMinCardinality> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectMinCardinality {
-                    n,
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
+    fn max(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMaxCardinality> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectMaxCardinality {
+            n,
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
+    }
 
-            fn max(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMaxCardinality> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectMaxCardinality {
-                    n,
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
+    fn exact(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectExactCardinality> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectExactCardinality {
+            n,
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
+    }
 
-            fn exact(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectExactCardinality> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectExactCardinality {
-                    n,
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
+    fn __invert__(&self) -> ObjectPropertyExpression {
+        let ope: ObjectPropertyExpression = self.clone().into();
+        let inner: ObjectPropertyExpression_Inner = match ope.0 {
+            ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty(i)) => {
+                ObjectPropertyExpression_Inner::ObjectProperty(i)
             }
-
-            fn __invert__(&self) -> ObjectPropertyExpression {
-                let ope: ObjectPropertyExpression = self.clone().into();
-                let inner: ObjectPropertyExpression_Inner = match ope.0 {
-                    ObjectPropertyExpression_Inner::InverseObjectProperty(
-                        InverseObjectProperty(i),
-                    ) => ObjectPropertyExpression_Inner::ObjectProperty(i),
-                    ObjectPropertyExpression_Inner::ObjectProperty(i) => {
-                        ObjectPropertyExpression_Inner::InverseObjectProperty(
-                            InverseObjectProperty(i),
-                        )
-                }
-                };
-
-                ObjectPropertyExpression(inner)
+            ObjectPropertyExpression_Inner::ObjectProperty(i) => {
+                ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty(i))
             }
-        }
+        };
+
+        ObjectPropertyExpression(inner)
+    }
+}
 #[doc = concat!(
     "Datatype(first: IRI,)",
     "\n\n",
     doc!(Datatype)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Datatype (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct Datatype(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl Datatype {
     #[new]
-    fn new(first: IRI,) -> Self {
-        Datatype (first,)
+    fn new(first: IRI) -> Self {
+        Datatype(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -1299,7 +1272,6 @@ impl Datatype {
     fn __eq__(&self, other: &Self) -> bool {
         self == other
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -1323,22 +1295,15 @@ impl Datatype {
 
 impl From<&horned_owl::model::Datatype<ArcStr>> for Datatype {
     fn from(value: &horned_owl::model::Datatype<ArcStr>) -> Self {
-
-        Datatype (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        Datatype(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&Datatype> for horned_owl::model::Datatype<ArcStr> {
     fn from(value: &Datatype) -> Self {
-        horned_owl::model::Datatype::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::Datatype::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for Datatype ****************/
 impl FromCompatible<horned_owl::model::Datatype<ArcStr>> for Datatype {
@@ -1468,44 +1433,42 @@ impl FromCompatible<&Vec<horned_owl::model::Datatype<ArcStr>>> for VecWrap<Datat
         VecWrap::<Datatype>::from(value)
     }
 }
-    /******** EXTENSION "named" for Datatype ********/
-    impl Display for Datatype {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0.0)
-        }
+/******** EXTENSION "named" for Datatype ********/
+impl Display for Datatype {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
     }
+}
 
-    #[pymethods]
-    impl Datatype {
-        fn __str__(&self) -> String {
-            self.to_string()
-        }
+#[pymethods]
+impl Datatype {
+    fn __str__(&self) -> String {
+        self.to_string()
     }
+}
 #[doc = concat!(
     "DataProperty(first: IRI,)",
     "\n\n",
     doc!(DataProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DataProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DataProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl DataProperty {
     #[new]
-    fn new(first: IRI,) -> Self {
-        DataProperty (first,)
+    fn new(first: IRI) -> Self {
+        DataProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -1517,7 +1480,6 @@ impl DataProperty {
     fn __eq__(&self, other: &Self) -> bool {
         self == other
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -1541,22 +1503,15 @@ impl DataProperty {
 
 impl From<&horned_owl::model::DataProperty<ArcStr>> for DataProperty {
     fn from(value: &horned_owl::model::DataProperty<ArcStr>) -> Self {
-
-        DataProperty (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        DataProperty(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&DataProperty> for horned_owl::model::DataProperty<ArcStr> {
     fn from(value: &DataProperty) -> Self {
-        horned_owl::model::DataProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DataProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DataProperty ****************/
 impl FromCompatible<horned_owl::model::DataProperty<ArcStr>> for DataProperty {
@@ -1686,58 +1641,55 @@ impl FromCompatible<&Vec<horned_owl::model::DataProperty<ArcStr>>> for VecWrap<D
         VecWrap::<DataProperty>::from(value)
     }
 }
-    /******** EXTENSION "named" for DataProperty ********/
-    impl Display for DataProperty {
-        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-            write!(f, "{}", self.0.0)
-        }
+/******** EXTENSION "named" for DataProperty ********/
+impl Display for DataProperty {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0 .0)
     }
+}
 
-    #[pymethods]
-    impl DataProperty {
-        fn __str__(&self) -> String {
-            self.to_string()
-        }
+#[pymethods]
+impl DataProperty {
+    fn __str__(&self) -> String {
+        self.to_string()
     }
+}
 #[doc = concat!("FacetRestriction(f: Facet,l: Literal,)",
     "\n\n",
     doc!(FacetRestriction)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct FacetRestriction {
-        #[doc="f: Facet"]
-        #[pyo3(get,set)]
-        pub f: Facet,
-    
-        #[doc="l: Literal"]
-        #[pyo3(get,set)]
-        pub l: Literal,
-    }
+    #[doc = "f: Facet"]
+    #[pyo3(get, set)]
+    pub f: Facet,
+
+    #[doc = "l: Literal"]
+    #[pyo3(get, set)]
+    pub l: Literal,
+}
 
 #[pymethods]
 impl FacetRestriction {
     #[new]
-    fn new(f: Facet,l: Literal,) -> Self {
-        FacetRestriction {
-                f,
-                l,
-        }
+    fn new(f: Facet, l: Literal) -> Self {
+        FacetRestriction { f, l }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "f".to_string(),
-            "l".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("f".to_string(), "l".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "f" => self.f.clone().into_pyobject(py).map(Bound::into_any),
             "l" => self.l.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -1746,12 +1698,15 @@ impl FacetRestriction {
             "f" => {
                 self.f = value.extract()?;
                 Ok(())
-            },
+            }
             "l" => {
                 self.l = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -1765,9 +1720,10 @@ impl FacetRestriction {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::FacetRestriction<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::FacetRestriction<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -1803,7 +1759,6 @@ impl From<&horned_owl::model::FacetRestriction<ArcStr>> for FacetRestriction {
     }
 }
 
-
 impl From<&FacetRestriction> for horned_owl::model::FacetRestriction<ArcStr> {
     fn from(value: &FacetRestriction) -> Self {
         horned_owl::model::FacetRestriction::<ArcStr> {
@@ -1812,8 +1767,6 @@ impl From<&FacetRestriction> for horned_owl::model::FacetRestriction<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for FacetRestriction ****************/
 impl FromCompatible<horned_owl::model::FacetRestriction<ArcStr>> for FacetRestriction {
@@ -1903,55 +1856,69 @@ impl From<&Vec<horned_owl::model::FacetRestriction<ArcStr>>> for VecWrap<FacetRe
     }
 }
 
-impl FromCompatible<&BoxWrap<FacetRestriction>> for Box<horned_owl::model::FacetRestriction<ArcStr>> {
+impl FromCompatible<&BoxWrap<FacetRestriction>>
+    for Box<horned_owl::model::FacetRestriction<ArcStr>>
+{
     fn from_c(value: &BoxWrap<FacetRestriction>) -> Self {
         Box::<horned_owl::model::FacetRestriction<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::FacetRestriction<ArcStr>>> for BoxWrap<FacetRestriction> {
+impl FromCompatible<&Box<horned_owl::model::FacetRestriction<ArcStr>>>
+    for BoxWrap<FacetRestriction>
+{
     fn from_c(value: &Box<horned_owl::model::FacetRestriction<ArcStr>>) -> Self {
         BoxWrap::<FacetRestriction>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<FacetRestriction>> for Box<horned_owl::model::FacetRestriction<ArcStr>> {
+impl FromCompatible<BoxWrap<FacetRestriction>>
+    for Box<horned_owl::model::FacetRestriction<ArcStr>>
+{
     fn from_c(value: BoxWrap<FacetRestriction>) -> Self {
         Box::<horned_owl::model::FacetRestriction<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::FacetRestriction<ArcStr>>> for BoxWrap<FacetRestriction> {
+impl FromCompatible<Box<horned_owl::model::FacetRestriction<ArcStr>>>
+    for BoxWrap<FacetRestriction>
+{
     fn from_c(value: Box<horned_owl::model::FacetRestriction<ArcStr>>) -> Self {
         BoxWrap::<FacetRestriction>::from(value)
     }
 }
-impl FromCompatible<VecWrap<FacetRestriction>> for Vec<horned_owl::model::FacetRestriction<ArcStr>> {
+impl FromCompatible<VecWrap<FacetRestriction>>
+    for Vec<horned_owl::model::FacetRestriction<ArcStr>>
+{
     fn from_c(value: VecWrap<FacetRestriction>) -> Self {
         Vec::<horned_owl::model::FacetRestriction<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::FacetRestriction<ArcStr>>> for VecWrap<FacetRestriction> {
+impl FromCompatible<Vec<horned_owl::model::FacetRestriction<ArcStr>>>
+    for VecWrap<FacetRestriction>
+{
     fn from_c(value: Vec<horned_owl::model::FacetRestriction<ArcStr>>) -> Self {
         VecWrap::<FacetRestriction>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<FacetRestriction>> for Vec<horned_owl::model::FacetRestriction<ArcStr>> {
+impl FromCompatible<&VecWrap<FacetRestriction>>
+    for Vec<horned_owl::model::FacetRestriction<ArcStr>>
+{
     fn from_c(value: &VecWrap<FacetRestriction>) -> Self {
         Vec::<horned_owl::model::FacetRestriction<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::FacetRestriction<ArcStr>>> for VecWrap<FacetRestriction> {
+impl FromCompatible<&Vec<horned_owl::model::FacetRestriction<ArcStr>>>
+    for VecWrap<FacetRestriction>
+{
     fn from_c(value: &Vec<horned_owl::model::FacetRestriction<ArcStr>>) -> Self {
         VecWrap::<FacetRestriction>::from(value)
     }
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Individual {
-    
-        #[pyo3(transparent)]
-        Anonymous (AnonymousIndividual),
-    
-        #[pyo3(transparent)]
-        Named (NamedIndividual),
-    
+    #[pyo3(transparent)]
+    Anonymous(AnonymousIndividual),
+
+    #[pyo3(transparent)]
+    Named(NamedIndividual),
 }
 
 impl<'py> IntoPyObject<'py> for Individual {
@@ -1961,11 +1928,9 @@ impl<'py> IntoPyObject<'py> for Individual {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
             Individual::Anonymous(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Individual::Named(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
         }
     }
 }
@@ -1973,36 +1938,28 @@ impl<'py> IntoPyObject<'py> for Individual {
 impl From<&Individual> for horned_owl::model::Individual<ArcStr> {
     fn from(value: &Individual) -> Self {
         match value {
-        
             Individual::Anonymous(inner) => horned_owl::model::Individual::Anonymous(inner.into()),
-        
+
             Individual::Named(inner) => horned_owl::model::Individual::Named(inner.into()),
-        
         }
     }
 }
 
 impl From<&horned_owl::model::Individual<ArcStr>> for Individual {
-
     fn from(value: &horned_owl::model::Individual<ArcStr>) -> Self {
         match value {
-        
             horned_owl::model::Individual::Anonymous(inner) => Individual::Anonymous(inner.into()),
-        
+
             horned_owl::model::Individual::Named(inner) => Individual::Named(inner.into()),
-        
         }
     }
 }
-
 
 impl Individual {
     pub fn py_def() -> String {
         "typing.Union[m.AnonymousIndividual,m.NamedIndividual,]".into()
     }
 }
-
-
 
 /**************** Base implementations for Individual ****************/
 impl FromCompatible<horned_owl::model::Individual<ArcStr>> for Individual {
@@ -2138,80 +2095,87 @@ impl FromCompatible<&Vec<horned_owl::model::Individual<ArcStr>>> for VecWrap<Ind
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum ObjectPropertyExpression_Inner {
     ObjectProperty(ObjectProperty),
-	InverseObjectProperty(InverseObjectProperty),
+    InverseObjectProperty(InverseObjectProperty),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectPropertyExpression(ObjectPropertyExpression_Inner);
 
-
 /**************** ENUM VARIANTS for ObjectPropertyExpression ****************/
 
-    /**************** ENUM VARIANT InverseObjectProperty for ObjectPropertyExpression ****************/
-    #[doc = concat!("InverseObjectProperty(first: ObjectProperty",
+/**************** ENUM VARIANT InverseObjectProperty for ObjectPropertyExpression ****************/
+#[doc = concat!("InverseObjectProperty(first: ObjectProperty",
         "\n\n",doc!(InverseObjectProperty))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct InverseObjectProperty(
-        #[pyo3(get,set,name="first")]
-        pub ObjectProperty,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct InverseObjectProperty(#[pyo3(get, set, name = "first")] pub ObjectProperty);
 
-    impl From<InverseObjectProperty> for ObjectPropertyExpression {
-        fn from(value: InverseObjectProperty) -> Self {
-            ObjectPropertyExpression(ObjectPropertyExpression_Inner::InverseObjectProperty(value))
+impl From<InverseObjectProperty> for ObjectPropertyExpression {
+    fn from(value: InverseObjectProperty) -> Self {
+        ObjectPropertyExpression(ObjectPropertyExpression_Inner::InverseObjectProperty(value))
+    }
+}
+
+#[pymethods]
+impl InverseObjectProperty {
+    #[new]
+    fn new(first: ObjectProperty) -> Self {
+        InverseObjectProperty(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl InverseObjectProperty {
-        #[new]
-        fn new(first: ObjectProperty,) -> Self {
-            InverseObjectProperty(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ObjectPropertyExpression<ArcStr>>::into(Into::<ObjectPropertyExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ObjectPropertyExpression<ArcStr>>::into(Into::<
+            ObjectPropertyExpression,
+        >::into(
+            self.clone()
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -2224,107 +2188,107 @@ pub struct ObjectPropertyExpression(ObjectPropertyExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ObjectPropertyExpression<ArcStr> = Into::<ObjectPropertyExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ObjectPropertyExpression<ArcStr> =
+            Into::<ObjectPropertyExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "object-property-expression" for InverseObjectProperty ********/
+#[pymethods]
+impl InverseObjectProperty {
+    fn some(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectSomeValuesFrom> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectSomeValuesFrom {
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
     }
 
-    
-    /******** EXTENSION "object-property-expression" for InverseObjectProperty ********/
-       #[pymethods]
-        impl InverseObjectProperty {
-            fn some(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectSomeValuesFrom> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectSomeValuesFrom {
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
-
-            fn only(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectAllValuesFrom> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectAllValuesFrom {
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
-
-            fn has_value(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectHasValue> {
-                let i: Individual = obj.extract()?;
-                Ok(ObjectHasValue{
-                    ope: self.clone().into(),
-                    i
-                })
-            }
-
-            fn has_self(&self) -> PyResult<ObjectHasSelf> {
-                Ok(ObjectHasSelf(self.clone().into()))
-            }
-
-            fn min(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMinCardinality> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectMinCardinality {
-                    n,
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
-
-            fn max(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMaxCardinality> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectMaxCardinality {
-                    n,
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
-
-            fn exact(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectExactCardinality> {
-                let ce: ClassExpression = obj.extract()?;
-                Ok(ObjectExactCardinality {
-                    n,
-                    ope: self.clone().into(),
-                    bce: Box::new(ce).into(),
-                })
-            }
-
-            fn __invert__(&self) -> ObjectPropertyExpression {
-                let ope: ObjectPropertyExpression = self.clone().into();
-                let inner: ObjectPropertyExpression_Inner = match ope.0 {
-                    ObjectPropertyExpression_Inner::InverseObjectProperty(
-                        InverseObjectProperty(i),
-                    ) => ObjectPropertyExpression_Inner::ObjectProperty(i),
-                    ObjectPropertyExpression_Inner::ObjectProperty(i) => {
-                        ObjectPropertyExpression_Inner::InverseObjectProperty(
-                            InverseObjectProperty(i),
-                        )
-                }
-                };
-
-                ObjectPropertyExpression(inner)
-            }
-        }
-
-    // Transparent variant implementation
-    impl From<ObjectProperty> for ObjectPropertyExpression {
-        fn from(value: ObjectProperty) -> Self {
-            ObjectPropertyExpression(ObjectPropertyExpression_Inner::ObjectProperty(value))
-        }
+    fn only(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectAllValuesFrom> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectAllValuesFrom {
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
     }
 
+    fn has_value(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectHasValue> {
+        let i: Individual = obj.extract()?;
+        Ok(ObjectHasValue {
+            ope: self.clone().into(),
+            i,
+        })
+    }
 
+    fn has_self(&self) -> PyResult<ObjectHasSelf> {
+        Ok(ObjectHasSelf(self.clone().into()))
+    }
+
+    fn min(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMinCardinality> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectMinCardinality {
+            n,
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
+    }
+
+    fn max(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectMaxCardinality> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectMaxCardinality {
+            n,
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
+    }
+
+    fn exact(&self, n: u32, obj: &Bound<'_, PyAny>) -> PyResult<ObjectExactCardinality> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectExactCardinality {
+            n,
+            ope: self.clone().into(),
+            bce: Box::new(ce).into(),
+        })
+    }
+
+    fn __invert__(&self) -> ObjectPropertyExpression {
+        let ope: ObjectPropertyExpression = self.clone().into();
+        let inner: ObjectPropertyExpression_Inner = match ope.0 {
+            ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty(i)) => {
+                ObjectPropertyExpression_Inner::ObjectProperty(i)
+            }
+            ObjectPropertyExpression_Inner::ObjectProperty(i) => {
+                ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty(i))
+            }
+        };
+
+        ObjectPropertyExpression(inner)
+    }
+}
+
+// Transparent variant implementation
+impl From<ObjectProperty> for ObjectPropertyExpression {
+    fn from(value: ObjectProperty) -> Self {
+        ObjectPropertyExpression(ObjectPropertyExpression_Inner::ObjectProperty(value))
+    }
+}
 
 impl From<&horned_owl::model::ObjectPropertyExpression<ArcStr>> for ObjectPropertyExpression {
     fn from(value: &horned_owl::model::ObjectPropertyExpression<ArcStr>) -> Self {
         match value {
-        		horned_owl::model::ObjectPropertyExpression::ObjectProperty::<ArcStr>(f0) =>
-                    ObjectPropertyExpression(ObjectPropertyExpression_Inner::ObjectProperty(f0.into())),
-                horned_owl::model::ObjectPropertyExpression::InverseObjectProperty::<ArcStr>(first) =>
-                    ObjectPropertyExpression(ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty((first).into(),))),
+            horned_owl::model::ObjectPropertyExpression::ObjectProperty::<ArcStr>(f0) => {
+                ObjectPropertyExpression(ObjectPropertyExpression_Inner::ObjectProperty(f0.into()))
+            }
+            horned_owl::model::ObjectPropertyExpression::InverseObjectProperty::<ArcStr>(first) => {
+                ObjectPropertyExpression(ObjectPropertyExpression_Inner::InverseObjectProperty(
+                    InverseObjectProperty((first).into()),
+                ))
+            }
         }
     }
 }
@@ -2332,11 +2296,14 @@ impl From<&horned_owl::model::ObjectPropertyExpression<ArcStr>> for ObjectProper
 impl From<&ObjectPropertyExpression> for horned_owl::model::ObjectPropertyExpression<ArcStr> {
     fn from(value: &ObjectPropertyExpression) -> Self {
         match value.0.borrow() {
-                ObjectPropertyExpression_Inner::ObjectProperty(f0) => horned_owl::model::ObjectPropertyExpression::<ArcStr>::ObjectProperty(f0.into()),
-                ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty(first)) =>
+            ObjectPropertyExpression_Inner::ObjectProperty(f0) => {
+                horned_owl::model::ObjectPropertyExpression::<ArcStr>::ObjectProperty(f0.into())
+            }
+            ObjectPropertyExpression_Inner::InverseObjectProperty(InverseObjectProperty(first)) => {
                 horned_owl::model::ObjectPropertyExpression::<ArcStr>::InverseObjectProperty(
                     first.into_c(),
-                ),
+                )
+            }
         }
     }
 }
@@ -2348,40 +2315,39 @@ impl<'py> IntoPyObject<'py> for ObjectPropertyExpression {
 
     fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
-            
-                ObjectPropertyExpression_Inner::ObjectProperty(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ObjectPropertyExpression_Inner::InverseObjectProperty(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
+            ObjectPropertyExpression_Inner::ObjectProperty(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ObjectPropertyExpression_Inner::InverseObjectProperty(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
         }
     }
-
 }
 
-impl <'py> FromPyObject<'_, 'py> for ObjectPropertyExpression {
+impl<'py> FromPyObject<'_, 'py> for ObjectPropertyExpression {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-            {
-            	let r = ObjectProperty::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ObjectPropertyExpression_Inner::ObjectProperty(local);
-                    return Ok(ObjectPropertyExpression(inner));
-                }
+        {
+            let r = ObjectProperty::extract(ob);
+            if let Ok(local) = r {
+                let inner = ObjectPropertyExpression_Inner::ObjectProperty(local);
+                return Ok(ObjectPropertyExpression(inner));
             }
-            {
-                let r = InverseObjectProperty::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ObjectPropertyExpression_Inner::InverseObjectProperty(local);
-                    return Ok(ObjectPropertyExpression(inner));
-                }
+        }
+        {
+            let r = InverseObjectProperty::extract(ob);
+            if let Ok(local) = r {
+                let inner = ObjectPropertyExpression_Inner::InverseObjectProperty(local);
+                return Ok(ObjectPropertyExpression(inner));
             }
+        }
 
-        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>("Object cannot be converted to ObjectPropertyExpression"))
+        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Object cannot be converted to ObjectPropertyExpression",
+        ))
     }
 }
 
@@ -2391,28 +2357,34 @@ impl ObjectPropertyExpression {
     }
 }
 
-
-
 /**************** Base implementations for ObjectPropertyExpression ****************/
-impl FromCompatible<horned_owl::model::ObjectPropertyExpression<ArcStr>> for ObjectPropertyExpression {
+impl FromCompatible<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+    for ObjectPropertyExpression
+{
     fn from_c(value: horned_owl::model::ObjectPropertyExpression<ArcStr>) -> Self {
         ObjectPropertyExpression::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::ObjectPropertyExpression<ArcStr>> for ObjectPropertyExpression {
+impl FromCompatible<&horned_owl::model::ObjectPropertyExpression<ArcStr>>
+    for ObjectPropertyExpression
+{
     fn from_c(value: &horned_owl::model::ObjectPropertyExpression<ArcStr>) -> Self {
         ObjectPropertyExpression::from(value)
     }
 }
 
-impl FromCompatible<ObjectPropertyExpression> for horned_owl::model::ObjectPropertyExpression<ArcStr> {
+impl FromCompatible<ObjectPropertyExpression>
+    for horned_owl::model::ObjectPropertyExpression<ArcStr>
+{
     fn from_c(value: ObjectPropertyExpression) -> Self {
         horned_owl::model::ObjectPropertyExpression::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&ObjectPropertyExpression> for horned_owl::model::ObjectPropertyExpression<ArcStr> {
+impl FromCompatible<&ObjectPropertyExpression>
+    for horned_owl::model::ObjectPropertyExpression<ArcStr>
+{
     fn from_c(value: &ObjectPropertyExpression) -> Self {
         horned_owl::model::ObjectPropertyExpression::<ArcStr>::from(value)
     }
@@ -2430,43 +2402,59 @@ impl From<ObjectPropertyExpression> for horned_owl::model::ObjectPropertyExpress
     }
 }
 
-impl From<&BoxWrap<ObjectPropertyExpression>> for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl From<&BoxWrap<ObjectPropertyExpression>>
+    for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from(value: &BoxWrap<ObjectPropertyExpression>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for BoxWrap<ObjectPropertyExpression> {
+impl From<&Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<ObjectPropertyExpression>
+{
     fn from(value: &Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<ObjectPropertyExpression>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<ObjectPropertyExpression>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<ObjectPropertyExpression>> for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl From<BoxWrap<ObjectPropertyExpression>>
+    for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from(value: BoxWrap<ObjectPropertyExpression>) -> Self {
         Into::<Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for BoxWrap<ObjectPropertyExpression> {
+impl From<Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<ObjectPropertyExpression>
+{
     fn from(value: Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         Into::<BoxWrap<ObjectPropertyExpression>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<ObjectPropertyExpression>> for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl From<VecWrap<ObjectPropertyExpression>>
+    for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from(value: VecWrap<ObjectPropertyExpression>) -> Self {
         Into::<Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for VecWrap<ObjectPropertyExpression> {
+impl From<Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for VecWrap<ObjectPropertyExpression>
+{
     fn from(value: Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         Into::<VecWrap<ObjectPropertyExpression>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<ObjectPropertyExpression>> for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl From<&VecWrap<ObjectPropertyExpression>>
+    for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from(value: &VecWrap<ObjectPropertyExpression>) -> Self {
         value
             .0
@@ -2475,48 +2463,66 @@ impl From<&VecWrap<ObjectPropertyExpression>> for Vec<horned_owl::model::ObjectP
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for VecWrap<ObjectPropertyExpression> {
+impl From<&Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for VecWrap<ObjectPropertyExpression>
+{
     fn from(value: &Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         VecWrap(value.iter().map(ObjectPropertyExpression::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<ObjectPropertyExpression>> for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<&BoxWrap<ObjectPropertyExpression>>
+    for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: &BoxWrap<ObjectPropertyExpression>) -> Self {
         Box::<horned_owl::model::ObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for BoxWrap<ObjectPropertyExpression> {
+impl FromCompatible<&Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<ObjectPropertyExpression>
+{
     fn from_c(value: &Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyExpression>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<ObjectPropertyExpression>> for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<BoxWrap<ObjectPropertyExpression>>
+    for Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: BoxWrap<ObjectPropertyExpression>) -> Self {
         Box::<horned_owl::model::ObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for BoxWrap<ObjectPropertyExpression> {
+impl FromCompatible<Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<ObjectPropertyExpression>
+{
     fn from_c(value: Box<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyExpression>::from(value)
     }
 }
-impl FromCompatible<VecWrap<ObjectPropertyExpression>> for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<VecWrap<ObjectPropertyExpression>>
+    for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: VecWrap<ObjectPropertyExpression>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for VecWrap<ObjectPropertyExpression> {
+impl FromCompatible<Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for VecWrap<ObjectPropertyExpression>
+{
     fn from_c(value: Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyExpression>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<ObjectPropertyExpression>> for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<&VecWrap<ObjectPropertyExpression>>
+    for Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: &VecWrap<ObjectPropertyExpression>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>> for VecWrap<ObjectPropertyExpression> {
+impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>>
+    for VecWrap<ObjectPropertyExpression>
+{
     fn from_c(value: &Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyExpression>::from(value)
     }
@@ -2526,81 +2532,89 @@ impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyExpression<ArcStr>>> f
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Literal_Inner {
-	Simple(SimpleLiteral),
-	Language(LanguageLiteral),
-	Datatype(DatatypeLiteral),
+    Simple(SimpleLiteral),
+    Language(LanguageLiteral),
+    Datatype(DatatypeLiteral),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Literal(Literal_Inner);
 
-
 /**************** ENUM VARIANTS for Literal ****************/
 
-    /**************** ENUM VARIANT SimpleLiteral for Literal ****************/
-    #[doc = concat!("SimpleLiteral(literal: str",
+/**************** ENUM VARIANT SimpleLiteral for Literal ****************/
+#[doc = concat!("SimpleLiteral(literal: str",
         "\n\n",doc!(SimpleLiteral))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct SimpleLiteral{
-        #[doc="literal: str"]
-        #[pyo3(get,set)]
-        pub literal: String,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SimpleLiteral {
+    #[doc = "literal: str"]
+    #[pyo3(get, set)]
+    pub literal: String,
+}
 
-    impl From<SimpleLiteral> for Literal {
-        fn from(value: SimpleLiteral) -> Self {
-            Literal(Literal_Inner::Simple(value))
+impl From<SimpleLiteral> for Literal {
+    fn from(value: SimpleLiteral) -> Self {
+        Literal(Literal_Inner::Simple(value))
+    }
+}
+
+#[pymethods]
+impl SimpleLiteral {
+    #[new]
+    fn new(literal: String) -> Self {
+        SimpleLiteral { literal }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("literal".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "literal" => self
+                .literal
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl SimpleLiteral {
-        #[new]
-        fn new(literal: String,) -> Self {
-            SimpleLiteral{
-                literal,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"literal".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"literal" => self.literal.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"literal" => {
-                    self.literal = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "literal" => {
+                self.literal = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Literal<ArcStr>>::into(Into::<Literal>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Literal<ArcStr>>::into(Into::<Literal>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -2620,85 +2634,94 @@ pub struct Literal(Literal_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT LanguageLiteral for Literal ****************/
-    #[doc = concat!("LanguageLiteral(literal: strlang: str",
+/**************** ENUM VARIANT LanguageLiteral for Literal ****************/
+#[doc = concat!("LanguageLiteral(literal: strlang: str",
         "\n\n",doc!(LanguageLiteral))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct LanguageLiteral{
-        #[doc="literal: str"]
-        #[pyo3(get,set)]
-        pub literal: String,
-        #[doc="lang: str"]
-        #[pyo3(get,set)]
-        pub lang: String,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct LanguageLiteral {
+    #[doc = "literal: str"]
+    #[pyo3(get, set)]
+    pub literal: String,
+    #[doc = "lang: str"]
+    #[pyo3(get, set)]
+    pub lang: String,
+}
 
-    impl From<LanguageLiteral> for Literal {
-        fn from(value: LanguageLiteral) -> Self {
-            Literal(Literal_Inner::Language(value))
+impl From<LanguageLiteral> for Literal {
+    fn from(value: LanguageLiteral) -> Self {
+        Literal(Literal_Inner::Language(value))
+    }
+}
+
+#[pymethods]
+impl LanguageLiteral {
+    #[new]
+    fn new(literal: String, lang: String) -> Self {
+        LanguageLiteral { literal, lang }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("literal".to_string(), "lang".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "literal" => self
+                .literal
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "lang" => self
+                .lang
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl LanguageLiteral {
-        #[new]
-        fn new(literal: String,lang: String,) -> Self {
-            LanguageLiteral{
-                literal,
-                lang,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"literal".to_string(),
-            	"lang".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"literal" => self.literal.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"lang" => self.lang.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"literal" => {
-                    self.literal = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "literal" => {
+                self.literal = value.extract()?;
                 Ok(())
-                },
-            	"lang" => {
-                    self.lang = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "lang" => {
+                self.lang = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Literal<ArcStr>>::into(Into::<Literal>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Literal<ArcStr>>::into(Into::<Literal>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -2718,85 +2741,97 @@ pub struct Literal(Literal_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DatatypeLiteral for Literal ****************/
-    #[doc = concat!("DatatypeLiteral(literal: strdatatype_iri: IRI",
+/**************** ENUM VARIANT DatatypeLiteral for Literal ****************/
+#[doc = concat!("DatatypeLiteral(literal: strdatatype_iri: IRI",
         "\n\n",doc!(DatatypeLiteral))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DatatypeLiteral{
-        #[doc="literal: str"]
-        #[pyo3(get,set)]
-        pub literal: String,
-        #[doc="datatype_iri: IRI"]
-        #[pyo3(get,set)]
-        pub datatype_iri: IRI,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DatatypeLiteral {
+    #[doc = "literal: str"]
+    #[pyo3(get, set)]
+    pub literal: String,
+    #[doc = "datatype_iri: IRI"]
+    #[pyo3(get, set)]
+    pub datatype_iri: IRI,
+}
 
-    impl From<DatatypeLiteral> for Literal {
-        fn from(value: DatatypeLiteral) -> Self {
-            Literal(Literal_Inner::Datatype(value))
+impl From<DatatypeLiteral> for Literal {
+    fn from(value: DatatypeLiteral) -> Self {
+        Literal(Literal_Inner::Datatype(value))
+    }
+}
+
+#[pymethods]
+impl DatatypeLiteral {
+    #[new]
+    fn new(literal: String, datatype_iri: IRI) -> Self {
+        DatatypeLiteral {
+            literal,
+            datatype_iri,
         }
     }
 
-    #[pymethods]
-    impl DatatypeLiteral {
-        #[new]
-        fn new(literal: String,datatype_iri: IRI,) -> Self {
-            DatatypeLiteral{
-                literal,
-                datatype_iri,}
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("literal".to_string(), "datatype_iri".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "literal" => self
+                .literal
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "datatype_iri" => self
+                .datatype_iri
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"literal".to_string(),
-            	"datatype_iri".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"literal" => self.literal.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"datatype_iri" => self.datatype_iri.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"literal" => {
-                    self.literal = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "literal" => {
+                self.literal = value.extract()?;
                 Ok(())
-                },
-            	"datatype_iri" => {
-                    self.datatype_iri = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "datatype_iri" => {
+                self.datatype_iri = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Literal<ArcStr>>::into(Into::<Literal>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Literal<ArcStr>>::into(Into::<Literal>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -2816,23 +2851,29 @@ pub struct Literal(Literal_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
-
-    
-
-
+}
 
 impl From<&horned_owl::model::Literal<ArcStr>> for Literal {
     fn from(value: &horned_owl::model::Literal<ArcStr>) -> Self {
-        match value {horned_owl::model::Literal::Simple::<ArcStr>{
-                    literal
-                } => Literal(Literal_Inner::Simple(SimpleLiteral{literal: IntoCompatible::<String>::into_c(literal),})),horned_owl::model::Literal::Language::<ArcStr>{
-                    literal,
-lang
-                } => Literal(Literal_Inner::Language(LanguageLiteral{literal: IntoCompatible::<String>::into_c(literal),lang: IntoCompatible::<String>::into_c(lang),})),horned_owl::model::Literal::Datatype::<ArcStr>{
-                    literal,
-datatype_iri
-                } => Literal(Literal_Inner::Datatype(DatatypeLiteral{literal: IntoCompatible::<String>::into_c(literal),datatype_iri: IntoCompatible::<IRI>::into_c(datatype_iri),})),
+        match value {
+            horned_owl::model::Literal::Simple::<ArcStr> { literal } => {
+                Literal(Literal_Inner::Simple(SimpleLiteral {
+                    literal: IntoCompatible::<String>::into_c(literal),
+                }))
+            }
+            horned_owl::model::Literal::Language::<ArcStr> { literal, lang } => {
+                Literal(Literal_Inner::Language(LanguageLiteral {
+                    literal: IntoCompatible::<String>::into_c(literal),
+                    lang: IntoCompatible::<String>::into_c(lang),
+                }))
+            }
+            horned_owl::model::Literal::Datatype::<ArcStr> {
+                literal,
+                datatype_iri,
+            } => Literal(Literal_Inner::Datatype(DatatypeLiteral {
+                literal: IntoCompatible::<String>::into_c(literal),
+                datatype_iri: IntoCompatible::<IRI>::into_c(datatype_iri),
+            })),
         }
     }
 }
@@ -2840,23 +2881,24 @@ datatype_iri
 impl From<&Literal> for horned_owl::model::Literal<ArcStr> {
     fn from(value: &Literal) -> Self {
         match value.0.borrow() {
-                Literal_Inner::Simple(SimpleLiteral{
-                    literal
-                }) => horned_owl::model::Literal::<ArcStr>::Simple{
-                	literal: literal.into_c(),
-                },
-                Literal_Inner::Language(LanguageLiteral{
-                    literal, lang
-                }) => horned_owl::model::Literal::<ArcStr>::Language{
-                	literal: literal.into_c(),
-                	lang: lang.into_c(),
-                },
-                Literal_Inner::Datatype(DatatypeLiteral{
-                    literal, datatype_iri
-                }) => horned_owl::model::Literal::<ArcStr>::Datatype{
-                	literal: literal.into_c(),
-                	datatype_iri: datatype_iri.into_c(),
-                },
+            Literal_Inner::Simple(SimpleLiteral { literal }) => {
+                horned_owl::model::Literal::<ArcStr>::Simple {
+                    literal: literal.into_c(),
+                }
+            }
+            Literal_Inner::Language(LanguageLiteral { literal, lang }) => {
+                horned_owl::model::Literal::<ArcStr>::Language {
+                    literal: literal.into_c(),
+                    lang: lang.into_c(),
+                }
+            }
+            Literal_Inner::Datatype(DatatypeLiteral {
+                literal,
+                datatype_iri,
+            }) => horned_owl::model::Literal::<ArcStr>::Datatype {
+                literal: literal.into_c(),
+                datatype_iri: datatype_iri.into_c(),
+            },
         }
     }
 }
@@ -2868,51 +2910,44 @@ impl<'py> IntoPyObject<'py> for Literal {
 
     fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
-            
-                Literal_Inner::Simple(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Literal_Inner::Language(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Literal_Inner::Datatype(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
+            Literal_Inner::Simple(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Literal_Inner::Language(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Literal_Inner::Datatype(val) => val.into_pyobject(py).map(Bound::into_any),
         }
     }
-
 }
 
-impl <'py> FromPyObject<'_, 'py> for Literal {
+impl<'py> FromPyObject<'_, 'py> for Literal {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-            {
-                let r = SimpleLiteral::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Literal_Inner::Simple(local);
-                    return Ok(Literal(inner));
-                }
+        {
+            let r = SimpleLiteral::extract(ob);
+            if let Ok(local) = r {
+                let inner = Literal_Inner::Simple(local);
+                return Ok(Literal(inner));
             }
-            {
-                let r = LanguageLiteral::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Literal_Inner::Language(local);
-                    return Ok(Literal(inner));
-                }
+        }
+        {
+            let r = LanguageLiteral::extract(ob);
+            if let Ok(local) = r {
+                let inner = Literal_Inner::Language(local);
+                return Ok(Literal(inner));
             }
-            {
-                let r = DatatypeLiteral::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Literal_Inner::Datatype(local);
-                    return Ok(Literal(inner));
-                }
+        }
+        {
+            let r = DatatypeLiteral::extract(ob);
+            if let Ok(local) = r {
+                let inner = Literal_Inner::Datatype(local);
+                return Ok(Literal(inner));
             }
+        }
 
-        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>("Object cannot be converted to Literal"))
+        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Object cannot be converted to Literal",
+        ))
     }
 }
 
@@ -2921,8 +2956,6 @@ impl Literal {
         "typing.Union[m.SimpleLiteral,m.LanguageLiteral,m.DatatypeLiteral,]".into()
     }
 }
-
-
 
 /**************** Base implementations for Literal ****************/
 impl FromCompatible<horned_owl::model::Literal<ArcStr>> for Literal {
@@ -3058,84 +3091,87 @@ impl FromCompatible<&Vec<horned_owl::model::Literal<ArcStr>>> for VecWrap<Litera
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum DataRange_Inner {
     Datatype(Datatype),
-	DataIntersectionOf(DataIntersectionOf),
-	DataUnionOf(DataUnionOf),
-	DataComplementOf(DataComplementOf),
-	DataOneOf(DataOneOf),
-	DatatypeRestriction(DatatypeRestriction),
+    DataIntersectionOf(DataIntersectionOf),
+    DataUnionOf(DataUnionOf),
+    DataComplementOf(DataComplementOf),
+    DataOneOf(DataOneOf),
+    DatatypeRestriction(DatatypeRestriction),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DataRange(DataRange_Inner);
 
-
 /**************** ENUM VARIANTS for DataRange ****************/
 
-    /**************** ENUM VARIANT DataIntersectionOf for DataRange ****************/
-    #[doc = concat!("DataIntersectionOf(first: typing.List[DataRange]",
+/**************** ENUM VARIANT DataIntersectionOf for DataRange ****************/
+#[doc = concat!("DataIntersectionOf(first: typing.List[DataRange]",
         "\n\n",doc!(DataIntersectionOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataIntersectionOf(
-        #[pyo3(get,set,name="first")]
-        pub VecWrap<DataRange>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataIntersectionOf(#[pyo3(get, set, name = "first")] pub VecWrap<DataRange>);
 
-    impl From<DataIntersectionOf> for DataRange {
-        fn from(value: DataIntersectionOf) -> Self {
-            DataRange(DataRange_Inner::DataIntersectionOf(value))
+impl From<DataIntersectionOf> for DataRange {
+    fn from(value: DataIntersectionOf) -> Self {
+        DataRange(DataRange_Inner::DataIntersectionOf(value))
+    }
+}
+
+#[pymethods]
+impl DataIntersectionOf {
+    #[new]
+    fn new(first: VecWrap<DataRange>) -> Self {
+        DataIntersectionOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataIntersectionOf {
-        #[new]
-        fn new(first: VecWrap<DataRange>,) -> Self {
-            DataIntersectionOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -3148,83 +3184,85 @@ pub struct DataRange(DataRange_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::DataRange<ArcStr> = Into::<DataRange>::into(self.clone()).into();
+        let value: horned_owl::model::DataRange<ArcStr> =
+            Into::<DataRange>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DataUnionOf for DataRange ****************/
-    #[doc = concat!("DataUnionOf(first: typing.List[DataRange]",
+/**************** ENUM VARIANT DataUnionOf for DataRange ****************/
+#[doc = concat!("DataUnionOf(first: typing.List[DataRange]",
         "\n\n",doc!(DataUnionOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataUnionOf(
-        #[pyo3(get,set,name="first")]
-        pub VecWrap<DataRange>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataUnionOf(#[pyo3(get, set, name = "first")] pub VecWrap<DataRange>);
 
-    impl From<DataUnionOf> for DataRange {
-        fn from(value: DataUnionOf) -> Self {
-            DataRange(DataRange_Inner::DataUnionOf(value))
+impl From<DataUnionOf> for DataRange {
+    fn from(value: DataUnionOf) -> Self {
+        DataRange(DataRange_Inner::DataUnionOf(value))
+    }
+}
+
+#[pymethods]
+impl DataUnionOf {
+    #[new]
+    fn new(first: VecWrap<DataRange>) -> Self {
+        DataUnionOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataUnionOf {
-        #[new]
-        fn new(first: VecWrap<DataRange>,) -> Self {
-            DataUnionOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -3237,83 +3275,85 @@ pub struct DataRange(DataRange_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::DataRange<ArcStr> = Into::<DataRange>::into(self.clone()).into();
+        let value: horned_owl::model::DataRange<ArcStr> =
+            Into::<DataRange>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DataComplementOf for DataRange ****************/
-    #[doc = concat!("DataComplementOf(first: DataRange",
+/**************** ENUM VARIANT DataComplementOf for DataRange ****************/
+#[doc = concat!("DataComplementOf(first: DataRange",
         "\n\n",doc!(DataComplementOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataComplementOf(
-        #[pyo3(get,set,name="first")]
-        pub BoxWrap<DataRange>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataComplementOf(#[pyo3(get, set, name = "first")] pub BoxWrap<DataRange>);
 
-    impl From<DataComplementOf> for DataRange {
-        fn from(value: DataComplementOf) -> Self {
-            DataRange(DataRange_Inner::DataComplementOf(value))
+impl From<DataComplementOf> for DataRange {
+    fn from(value: DataComplementOf) -> Self {
+        DataRange(DataRange_Inner::DataComplementOf(value))
+    }
+}
+
+#[pymethods]
+impl DataComplementOf {
+    #[new]
+    fn new(first: BoxWrap<DataRange>) -> Self {
+        DataComplementOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataComplementOf {
-        #[new]
-        fn new(first: BoxWrap<DataRange>,) -> Self {
-            DataComplementOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -3326,83 +3366,85 @@ pub struct DataRange(DataRange_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::DataRange<ArcStr> = Into::<DataRange>::into(self.clone()).into();
+        let value: horned_owl::model::DataRange<ArcStr> =
+            Into::<DataRange>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DataOneOf for DataRange ****************/
-    #[doc = concat!("DataOneOf(first: typing.List[Literal]",
+/**************** ENUM VARIANT DataOneOf for DataRange ****************/
+#[doc = concat!("DataOneOf(first: typing.List[Literal]",
         "\n\n",doc!(DataOneOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataOneOf(
-        #[pyo3(get,set,name="first")]
-        pub VecWrap<Literal>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataOneOf(#[pyo3(get, set, name = "first")] pub VecWrap<Literal>);
 
-    impl From<DataOneOf> for DataRange {
-        fn from(value: DataOneOf) -> Self {
-            DataRange(DataRange_Inner::DataOneOf(value))
+impl From<DataOneOf> for DataRange {
+    fn from(value: DataOneOf) -> Self {
+        DataRange(DataRange_Inner::DataOneOf(value))
+    }
+}
+
+#[pymethods]
+impl DataOneOf {
+    #[new]
+    fn new(first: VecWrap<Literal>) -> Self {
+        DataOneOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataOneOf {
-        #[new]
-        fn new(first: VecWrap<Literal>,) -> Self {
-            DataOneOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -3415,92 +3457,98 @@ pub struct DataRange(DataRange_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::DataRange<ArcStr> = Into::<DataRange>::into(self.clone()).into();
+        let value: horned_owl::model::DataRange<ArcStr> =
+            Into::<DataRange>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DatatypeRestriction for DataRange ****************/
-    #[doc = concat!("DatatypeRestriction(first: Datatypesecond: typing.List[FacetRestriction]",
+/**************** ENUM VARIANT DatatypeRestriction for DataRange ****************/
+#[doc = concat!("DatatypeRestriction(first: Datatypesecond: typing.List[FacetRestriction]",
         "\n\n",doc!(DatatypeRestriction))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DatatypeRestriction(
-        #[pyo3(get,set,name="first")]
-        pub Datatype,
-        #[pyo3(get,set,name="second")]
-        pub VecWrap<FacetRestriction>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DatatypeRestriction(
+    #[pyo3(get, set, name = "first")] pub Datatype,
+    #[pyo3(get, set, name = "second")] pub VecWrap<FacetRestriction>,
+);
 
-    impl From<DatatypeRestriction> for DataRange {
-        fn from(value: DatatypeRestriction) -> Self {
-            DataRange(DataRange_Inner::DatatypeRestriction(value))
+impl From<DatatypeRestriction> for DataRange {
+    fn from(value: DatatypeRestriction) -> Self {
+        DataRange(DataRange_Inner::DatatypeRestriction(value))
+    }
+}
+
+#[pymethods]
+impl DatatypeRestriction {
+    #[new]
+    fn new(first: Datatype, second: VecWrap<FacetRestriction>) -> Self {
+        DatatypeRestriction(first, second)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("first".to_string(), "second".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "second" => self
+                .1
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DatatypeRestriction {
-        #[new]
-        fn new(first: Datatype,second: VecWrap<FacetRestriction>,) -> Self {
-            DatatypeRestriction(
-                first,
-                second,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"first".to_string(),
-            	"second".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"second" => self.1.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-            	"second" => {
-                    self.1 = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "second" => {
+                self.1 = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::DataRange<ArcStr>>::into(Into::<DataRange>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -3513,41 +3561,47 @@ pub struct DataRange(DataRange_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::DataRange<ArcStr> = Into::<DataRange>::into(self.clone()).into();
+        let value: horned_owl::model::DataRange<ArcStr> =
+            Into::<DataRange>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+// Transparent variant implementation
+impl From<Datatype> for DataRange {
+    fn from(value: Datatype) -> Self {
+        DataRange(DataRange_Inner::Datatype(value))
     }
-
-    
-
-    // Transparent variant implementation
-    impl From<Datatype> for DataRange {
-        fn from(value: Datatype) -> Self {
-            DataRange(DataRange_Inner::Datatype(value))
-        }
-    }
-
-
+}
 
 impl From<&horned_owl::model::DataRange<ArcStr>> for DataRange {
     fn from(value: &horned_owl::model::DataRange<ArcStr>) -> Self {
         match value {
-        		horned_owl::model::DataRange::Datatype::<ArcStr>(f0) =>
-                    DataRange(DataRange_Inner::Datatype(f0.into())),
-                horned_owl::model::DataRange::DataIntersectionOf::<ArcStr>(first) =>
-                    DataRange(DataRange_Inner::DataIntersectionOf(DataIntersectionOf((first).into(),))),
-                horned_owl::model::DataRange::DataUnionOf::<ArcStr>(first) =>
-                    DataRange(DataRange_Inner::DataUnionOf(DataUnionOf((first).into(),))),
-                horned_owl::model::DataRange::DataComplementOf::<ArcStr>(first) =>
-                    DataRange(DataRange_Inner::DataComplementOf(DataComplementOf((first).into(),))),
-                horned_owl::model::DataRange::DataOneOf::<ArcStr>(first) =>
-                    DataRange(DataRange_Inner::DataOneOf(DataOneOf((first).into(),))),
-                horned_owl::model::DataRange::DatatypeRestriction::<ArcStr>(first, second) =>
-                    DataRange(DataRange_Inner::DatatypeRestriction(DatatypeRestriction((first).into(),(second).into(),))),
+            horned_owl::model::DataRange::Datatype::<ArcStr>(f0) => {
+                DataRange(DataRange_Inner::Datatype(f0.into()))
+            }
+            horned_owl::model::DataRange::DataIntersectionOf::<ArcStr>(first) => DataRange(
+                DataRange_Inner::DataIntersectionOf(DataIntersectionOf((first).into())),
+            ),
+            horned_owl::model::DataRange::DataUnionOf::<ArcStr>(first) => {
+                DataRange(DataRange_Inner::DataUnionOf(DataUnionOf((first).into())))
+            }
+            horned_owl::model::DataRange::DataComplementOf::<ArcStr>(first) => DataRange(
+                DataRange_Inner::DataComplementOf(DataComplementOf((first).into())),
+            ),
+            horned_owl::model::DataRange::DataOneOf::<ArcStr>(first) => {
+                DataRange(DataRange_Inner::DataOneOf(DataOneOf((first).into())))
+            }
+            horned_owl::model::DataRange::DatatypeRestriction::<ArcStr>(first, second) => {
+                DataRange(DataRange_Inner::DatatypeRestriction(DatatypeRestriction(
+                    (first).into(),
+                    (second).into(),
+                )))
+            }
         }
     }
 }
@@ -3555,28 +3609,27 @@ impl From<&horned_owl::model::DataRange<ArcStr>> for DataRange {
 impl From<&DataRange> for horned_owl::model::DataRange<ArcStr> {
     fn from(value: &DataRange) -> Self {
         match value.0.borrow() {
-                DataRange_Inner::Datatype(f0) => horned_owl::model::DataRange::<ArcStr>::Datatype(f0.into()),
-                DataRange_Inner::DataIntersectionOf(DataIntersectionOf(first)) =>
-                horned_owl::model::DataRange::<ArcStr>::DataIntersectionOf(
-                    first.into_c(),
-                ),
-                DataRange_Inner::DataUnionOf(DataUnionOf(first)) =>
-                horned_owl::model::DataRange::<ArcStr>::DataUnionOf(
-                    first.into_c(),
-                ),
-                DataRange_Inner::DataComplementOf(DataComplementOf(first)) =>
-                horned_owl::model::DataRange::<ArcStr>::DataComplementOf(
-                    first.into_c(),
-                ),
-                DataRange_Inner::DataOneOf(DataOneOf(first)) =>
-                horned_owl::model::DataRange::<ArcStr>::DataOneOf(
-                    first.into_c(),
-                ),
-                DataRange_Inner::DatatypeRestriction(DatatypeRestriction(first, second)) =>
+            DataRange_Inner::Datatype(f0) => {
+                horned_owl::model::DataRange::<ArcStr>::Datatype(f0.into())
+            }
+            DataRange_Inner::DataIntersectionOf(DataIntersectionOf(first)) => {
+                horned_owl::model::DataRange::<ArcStr>::DataIntersectionOf(first.into_c())
+            }
+            DataRange_Inner::DataUnionOf(DataUnionOf(first)) => {
+                horned_owl::model::DataRange::<ArcStr>::DataUnionOf(first.into_c())
+            }
+            DataRange_Inner::DataComplementOf(DataComplementOf(first)) => {
+                horned_owl::model::DataRange::<ArcStr>::DataComplementOf(first.into_c())
+            }
+            DataRange_Inner::DataOneOf(DataOneOf(first)) => {
+                horned_owl::model::DataRange::<ArcStr>::DataOneOf(first.into_c())
+            }
+            DataRange_Inner::DatatypeRestriction(DatatypeRestriction(first, second)) => {
                 horned_owl::model::DataRange::<ArcStr>::DatatypeRestriction(
                     first.into_c(),
                     second.into_c(),
-                ),
+                )
+            }
         }
     }
 }
@@ -3588,84 +3641,71 @@ impl<'py> IntoPyObject<'py> for DataRange {
 
     fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
-            
-                DataRange_Inner::Datatype(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                DataRange_Inner::DataIntersectionOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                DataRange_Inner::DataUnionOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                DataRange_Inner::DataComplementOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                DataRange_Inner::DataOneOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                DataRange_Inner::DatatypeRestriction(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
+            DataRange_Inner::Datatype(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            DataRange_Inner::DataIntersectionOf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            DataRange_Inner::DataUnionOf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            DataRange_Inner::DataComplementOf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            DataRange_Inner::DataOneOf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            DataRange_Inner::DatatypeRestriction(val) => val.into_pyobject(py).map(Bound::into_any),
         }
     }
-
 }
 
-impl <'py> FromPyObject<'_, 'py> for DataRange {
+impl<'py> FromPyObject<'_, 'py> for DataRange {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-            {
-            	let r = Datatype::extract(ob);
-                if let Ok(local) = r {
-                    let inner = DataRange_Inner::Datatype(local);
-                    return Ok(DataRange(inner));
-                }
+        {
+            let r = Datatype::extract(ob);
+            if let Ok(local) = r {
+                let inner = DataRange_Inner::Datatype(local);
+                return Ok(DataRange(inner));
             }
-            {
-                let r = DataIntersectionOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = DataRange_Inner::DataIntersectionOf(local);
-                    return Ok(DataRange(inner));
-                }
+        }
+        {
+            let r = DataIntersectionOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = DataRange_Inner::DataIntersectionOf(local);
+                return Ok(DataRange(inner));
             }
-            {
-                let r = DataUnionOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = DataRange_Inner::DataUnionOf(local);
-                    return Ok(DataRange(inner));
-                }
+        }
+        {
+            let r = DataUnionOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = DataRange_Inner::DataUnionOf(local);
+                return Ok(DataRange(inner));
             }
-            {
-                let r = DataComplementOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = DataRange_Inner::DataComplementOf(local);
-                    return Ok(DataRange(inner));
-                }
+        }
+        {
+            let r = DataComplementOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = DataRange_Inner::DataComplementOf(local);
+                return Ok(DataRange(inner));
             }
-            {
-                let r = DataOneOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = DataRange_Inner::DataOneOf(local);
-                    return Ok(DataRange(inner));
-                }
+        }
+        {
+            let r = DataOneOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = DataRange_Inner::DataOneOf(local);
+                return Ok(DataRange(inner));
             }
-            {
-                let r = DatatypeRestriction::extract(ob);
-                if let Ok(local) = r {
-                    let inner = DataRange_Inner::DatatypeRestriction(local);
-                    return Ok(DataRange(inner));
-                }
+        }
+        {
+            let r = DatatypeRestriction::extract(ob);
+            if let Ok(local) = r {
+                let inner = DataRange_Inner::DatatypeRestriction(local);
+                return Ok(DataRange(inner));
             }
+        }
 
-        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>("Object cannot be converted to DataRange"))
+        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Object cannot be converted to DataRange",
+        ))
     }
 }
 
@@ -3674,8 +3714,6 @@ impl DataRange {
         "typing.Union[m.Datatype,m.DataIntersectionOf,m.DataUnionOf,m.DataComplementOf,m.DataOneOf,m.DatatypeRestriction,]".into()
     }
 }
-
-
 
 /**************** Base implementations for DataRange ****************/
 impl FromCompatible<horned_owl::model::DataRange<ArcStr>> for DataRange {
@@ -3811,96 +3849,101 @@ impl FromCompatible<&Vec<horned_owl::model::DataRange<ArcStr>>> for VecWrap<Data
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum ClassExpression_Inner {
     Class(Class),
-	ObjectIntersectionOf(ObjectIntersectionOf),
-	ObjectUnionOf(ObjectUnionOf),
-	ObjectComplementOf(ObjectComplementOf),
-	ObjectOneOf(ObjectOneOf),
-	ObjectSomeValuesFrom(ObjectSomeValuesFrom),
-	ObjectAllValuesFrom(ObjectAllValuesFrom),
-	ObjectHasValue(ObjectHasValue),
-	ObjectHasSelf(ObjectHasSelf),
-	ObjectMinCardinality(ObjectMinCardinality),
-	ObjectMaxCardinality(ObjectMaxCardinality),
-	ObjectExactCardinality(ObjectExactCardinality),
-	DataSomeValuesFrom(DataSomeValuesFrom),
-	DataAllValuesFrom(DataAllValuesFrom),
-	DataHasValue(DataHasValue),
-	DataMinCardinality(DataMinCardinality),
-	DataMaxCardinality(DataMaxCardinality),
-	DataExactCardinality(DataExactCardinality),
+    ObjectIntersectionOf(ObjectIntersectionOf),
+    ObjectUnionOf(ObjectUnionOf),
+    ObjectComplementOf(ObjectComplementOf),
+    ObjectOneOf(ObjectOneOf),
+    ObjectSomeValuesFrom(ObjectSomeValuesFrom),
+    ObjectAllValuesFrom(ObjectAllValuesFrom),
+    ObjectHasValue(ObjectHasValue),
+    ObjectHasSelf(ObjectHasSelf),
+    ObjectMinCardinality(ObjectMinCardinality),
+    ObjectMaxCardinality(ObjectMaxCardinality),
+    ObjectExactCardinality(ObjectExactCardinality),
+    DataSomeValuesFrom(DataSomeValuesFrom),
+    DataAllValuesFrom(DataAllValuesFrom),
+    DataHasValue(DataHasValue),
+    DataMinCardinality(DataMinCardinality),
+    DataMaxCardinality(DataMaxCardinality),
+    DataExactCardinality(DataExactCardinality),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassExpression(ClassExpression_Inner);
 
-
 /**************** ENUM VARIANTS for ClassExpression ****************/
 
-    /**************** ENUM VARIANT ObjectIntersectionOf for ClassExpression ****************/
-    #[doc = concat!("ObjectIntersectionOf(first: typing.List[ClassExpression]",
+/**************** ENUM VARIANT ObjectIntersectionOf for ClassExpression ****************/
+#[doc = concat!("ObjectIntersectionOf(first: typing.List[ClassExpression]",
         "\n\n",doc!(ObjectIntersectionOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectIntersectionOf(
-        #[pyo3(get,set,name="first")]
-        pub VecWrap<ClassExpression>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectIntersectionOf(#[pyo3(get, set, name = "first")] pub VecWrap<ClassExpression>);
 
-    impl From<ObjectIntersectionOf> for ClassExpression {
-        fn from(value: ObjectIntersectionOf) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectIntersectionOf(value))
+impl From<ObjectIntersectionOf> for ClassExpression {
+    fn from(value: ObjectIntersectionOf) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectIntersectionOf(value))
+    }
+}
+
+#[pymethods]
+impl ObjectIntersectionOf {
+    #[new]
+    fn new(first: VecWrap<ClassExpression>) -> Self {
+        ObjectIntersectionOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectIntersectionOf {
-        #[new]
-        fn new(first: VecWrap<ClassExpression>,) -> Self {
-            ObjectIntersectionOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -3913,100 +3956,105 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectIntersectionOf ********/
+#[pymethods]
+impl ObjectIntersectionOf {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectIntersectionOf ********/
-    #[pymethods]
-    impl ObjectIntersectionOf {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectUnionOf for ClassExpression ****************/
-    #[doc = concat!("ObjectUnionOf(first: typing.List[ClassExpression]",
+/**************** ENUM VARIANT ObjectUnionOf for ClassExpression ****************/
+#[doc = concat!("ObjectUnionOf(first: typing.List[ClassExpression]",
         "\n\n",doc!(ObjectUnionOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectUnionOf(
-        #[pyo3(get,set,name="first")]
-        pub VecWrap<ClassExpression>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectUnionOf(#[pyo3(get, set, name = "first")] pub VecWrap<ClassExpression>);
 
-    impl From<ObjectUnionOf> for ClassExpression {
-        fn from(value: ObjectUnionOf) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectUnionOf(value))
+impl From<ObjectUnionOf> for ClassExpression {
+    fn from(value: ObjectUnionOf) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectUnionOf(value))
+    }
+}
+
+#[pymethods]
+impl ObjectUnionOf {
+    #[new]
+    fn new(first: VecWrap<ClassExpression>) -> Self {
+        ObjectUnionOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectUnionOf {
-        #[new]
-        fn new(first: VecWrap<ClassExpression>,) -> Self {
-            ObjectUnionOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4019,100 +4067,105 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectUnionOf ********/
+#[pymethods]
+impl ObjectUnionOf {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectUnionOf ********/
-    #[pymethods]
-    impl ObjectUnionOf {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectComplementOf for ClassExpression ****************/
-    #[doc = concat!("ObjectComplementOf(first: ClassExpression",
+/**************** ENUM VARIANT ObjectComplementOf for ClassExpression ****************/
+#[doc = concat!("ObjectComplementOf(first: ClassExpression",
         "\n\n",doc!(ObjectComplementOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectComplementOf(
-        #[pyo3(get,set,name="first")]
-        pub BoxWrap<ClassExpression>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectComplementOf(#[pyo3(get, set, name = "first")] pub BoxWrap<ClassExpression>);
 
-    impl From<ObjectComplementOf> for ClassExpression {
-        fn from(value: ObjectComplementOf) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectComplementOf(value))
+impl From<ObjectComplementOf> for ClassExpression {
+    fn from(value: ObjectComplementOf) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectComplementOf(value))
+    }
+}
+
+#[pymethods]
+impl ObjectComplementOf {
+    #[new]
+    fn new(first: BoxWrap<ClassExpression>) -> Self {
+        ObjectComplementOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectComplementOf {
-        #[new]
-        fn new(first: BoxWrap<ClassExpression>,) -> Self {
-            ObjectComplementOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4125,100 +4178,105 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectComplementOf ********/
+#[pymethods]
+impl ObjectComplementOf {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectComplementOf ********/
-    #[pymethods]
-    impl ObjectComplementOf {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectOneOf for ClassExpression ****************/
-    #[doc = concat!("ObjectOneOf(first: typing.List[Individual]",
+/**************** ENUM VARIANT ObjectOneOf for ClassExpression ****************/
+#[doc = concat!("ObjectOneOf(first: typing.List[Individual]",
         "\n\n",doc!(ObjectOneOf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectOneOf(
-        #[pyo3(get,set,name="first")]
-        pub VecWrap<Individual>,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectOneOf(#[pyo3(get, set, name = "first")] pub VecWrap<Individual>);
 
-    impl From<ObjectOneOf> for ClassExpression {
-        fn from(value: ObjectOneOf) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectOneOf(value))
+impl From<ObjectOneOf> for ClassExpression {
+    fn from(value: ObjectOneOf) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectOneOf(value))
+    }
+}
+
+#[pymethods]
+impl ObjectOneOf {
+    #[new]
+    fn new(first: VecWrap<Individual>) -> Self {
+        ObjectOneOf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectOneOf {
-        #[new]
-        fn new(first: VecWrap<Individual>,) -> Self {
-            ObjectOneOf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4231,109 +4289,122 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectOneOf ********/
+#[pymethods]
+impl ObjectOneOf {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectOneOf ********/
-    #[pymethods]
-    impl ObjectOneOf {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectSomeValuesFrom for ClassExpression ****************/
-    #[doc = concat!("ObjectSomeValuesFrom(ope: ObjectPropertyExpressionbce: ClassExpression",
+/**************** ENUM VARIANT ObjectSomeValuesFrom for ClassExpression ****************/
+#[doc = concat!("ObjectSomeValuesFrom(ope: ObjectPropertyExpressionbce: ClassExpression",
         "\n\n",doc!(ObjectSomeValuesFrom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectSomeValuesFrom{
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-        #[doc="bce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub bce: BoxWrap<ClassExpression>,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectSomeValuesFrom {
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+    #[doc = "bce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub bce: BoxWrap<ClassExpression>,
+}
 
-    impl From<ObjectSomeValuesFrom> for ClassExpression {
-        fn from(value: ObjectSomeValuesFrom) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectSomeValuesFrom(value))
+impl From<ObjectSomeValuesFrom> for ClassExpression {
+    fn from(value: ObjectSomeValuesFrom) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectSomeValuesFrom(value))
+    }
+}
+
+#[pymethods]
+impl ObjectSomeValuesFrom {
+    #[new]
+    fn new(ope: ObjectPropertyExpression, bce: BoxWrap<ClassExpression>) -> Self {
+        ObjectSomeValuesFrom { ope, bce }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ope".to_string(), "bce".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "ope" => self
+                .ope
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "bce" => self
+                .bce
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectSomeValuesFrom {
-        #[new]
-        fn new(ope: ObjectPropertyExpression,bce: BoxWrap<ClassExpression>,) -> Self {
-            ObjectSomeValuesFrom{
-                ope,
-                bce,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"ope".to_string(),
-            	"bce".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"bce" => self.bce.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"ope" => {
-                    self.ope = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "ope" => {
+                self.ope = value.extract()?;
                 Ok(())
-                },
-            	"bce" => {
-                    self.bce = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "bce" => {
+                self.bce = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4346,109 +4417,122 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectSomeValuesFrom ********/
+#[pymethods]
+impl ObjectSomeValuesFrom {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectSomeValuesFrom ********/
-    #[pymethods]
-    impl ObjectSomeValuesFrom {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectAllValuesFrom for ClassExpression ****************/
-    #[doc = concat!("ObjectAllValuesFrom(ope: ObjectPropertyExpressionbce: ClassExpression",
+/**************** ENUM VARIANT ObjectAllValuesFrom for ClassExpression ****************/
+#[doc = concat!("ObjectAllValuesFrom(ope: ObjectPropertyExpressionbce: ClassExpression",
         "\n\n",doc!(ObjectAllValuesFrom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectAllValuesFrom{
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-        #[doc="bce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub bce: BoxWrap<ClassExpression>,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectAllValuesFrom {
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+    #[doc = "bce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub bce: BoxWrap<ClassExpression>,
+}
 
-    impl From<ObjectAllValuesFrom> for ClassExpression {
-        fn from(value: ObjectAllValuesFrom) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectAllValuesFrom(value))
+impl From<ObjectAllValuesFrom> for ClassExpression {
+    fn from(value: ObjectAllValuesFrom) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectAllValuesFrom(value))
+    }
+}
+
+#[pymethods]
+impl ObjectAllValuesFrom {
+    #[new]
+    fn new(ope: ObjectPropertyExpression, bce: BoxWrap<ClassExpression>) -> Self {
+        ObjectAllValuesFrom { ope, bce }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ope".to_string(), "bce".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "ope" => self
+                .ope
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "bce" => self
+                .bce
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectAllValuesFrom {
-        #[new]
-        fn new(ope: ObjectPropertyExpression,bce: BoxWrap<ClassExpression>,) -> Self {
-            ObjectAllValuesFrom{
-                ope,
-                bce,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"ope".to_string(),
-            	"bce".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"bce" => self.bce.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"ope" => {
-                    self.ope = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "ope" => {
+                self.ope = value.extract()?;
                 Ok(())
-                },
-            	"bce" => {
-                    self.bce = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "bce" => {
+                self.bce = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4461,109 +4545,122 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectAllValuesFrom ********/
+#[pymethods]
+impl ObjectAllValuesFrom {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectAllValuesFrom ********/
-    #[pymethods]
-    impl ObjectAllValuesFrom {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectHasValue for ClassExpression ****************/
-    #[doc = concat!("ObjectHasValue(ope: ObjectPropertyExpressioni: Individual",
+/**************** ENUM VARIANT ObjectHasValue for ClassExpression ****************/
+#[doc = concat!("ObjectHasValue(ope: ObjectPropertyExpressioni: Individual",
         "\n\n",doc!(ObjectHasValue))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectHasValue{
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-        #[doc="i: Individual"]
-        #[pyo3(get,set)]
-        pub i: Individual,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectHasValue {
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+    #[doc = "i: Individual"]
+    #[pyo3(get, set)]
+    pub i: Individual,
+}
 
-    impl From<ObjectHasValue> for ClassExpression {
-        fn from(value: ObjectHasValue) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectHasValue(value))
+impl From<ObjectHasValue> for ClassExpression {
+    fn from(value: ObjectHasValue) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectHasValue(value))
+    }
+}
+
+#[pymethods]
+impl ObjectHasValue {
+    #[new]
+    fn new(ope: ObjectPropertyExpression, i: Individual) -> Self {
+        ObjectHasValue { ope, i }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ope".to_string(), "i".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "ope" => self
+                .ope
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "i" => self
+                .i
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectHasValue {
-        #[new]
-        fn new(ope: ObjectPropertyExpression,i: Individual,) -> Self {
-            ObjectHasValue{
-                ope,
-                i,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"ope".to_string(),
-            	"i".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"i" => self.i.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"ope" => {
-                    self.ope = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "ope" => {
+                self.ope = value.extract()?;
                 Ok(())
-                },
-            	"i" => {
-                    self.i = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "i" => {
+                self.i = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4576,100 +4673,105 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectHasValue ********/
+#[pymethods]
+impl ObjectHasValue {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectHasValue ********/
-    #[pymethods]
-    impl ObjectHasValue {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectHasSelf for ClassExpression ****************/
-    #[doc = concat!("ObjectHasSelf(first: ObjectPropertyExpression",
+/**************** ENUM VARIANT ObjectHasSelf for ClassExpression ****************/
+#[doc = concat!("ObjectHasSelf(first: ObjectPropertyExpression",
         "\n\n",doc!(ObjectHasSelf))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectHasSelf(
-        #[pyo3(get,set,name="first")]
-        pub ObjectPropertyExpression,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectHasSelf(#[pyo3(get, set, name = "first")] pub ObjectPropertyExpression);
 
-    impl From<ObjectHasSelf> for ClassExpression {
-        fn from(value: ObjectHasSelf) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectHasSelf(value))
+impl From<ObjectHasSelf> for ClassExpression {
+    fn from(value: ObjectHasSelf) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectHasSelf(value))
+    }
+}
+
+#[pymethods]
+impl ObjectHasSelf {
+    #[new]
+    fn new(first: ObjectPropertyExpression) -> Self {
+        ObjectHasSelf(first)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String,)> {
+        Ok(("first".to_string(),))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectHasSelf {
-        #[new]
-        fn new(first: ObjectPropertyExpression,) -> Self {
-            ObjectHasSelf(
-                first,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String,)> {
-            Ok((
-            	"first".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4682,119 +4784,135 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectHasSelf ********/
+#[pymethods]
+impl ObjectHasSelf {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectHasSelf ********/
-    #[pymethods]
-    impl ObjectHasSelf {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectMinCardinality for ClassExpression ****************/
-    #[doc = concat!("ObjectMinCardinality(n: intope: ObjectPropertyExpressionbce: ClassExpression",
+/**************** ENUM VARIANT ObjectMinCardinality for ClassExpression ****************/
+#[doc = concat!("ObjectMinCardinality(n: intope: ObjectPropertyExpressionbce: ClassExpression",
         "\n\n",doc!(ObjectMinCardinality))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectMinCardinality{
-        #[doc="n: int"]
-        #[pyo3(get,set)]
-        pub n: u32,
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-        #[doc="bce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub bce: BoxWrap<ClassExpression>,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectMinCardinality {
+    #[doc = "n: int"]
+    #[pyo3(get, set)]
+    pub n: u32,
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+    #[doc = "bce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub bce: BoxWrap<ClassExpression>,
+}
 
-    impl From<ObjectMinCardinality> for ClassExpression {
-        fn from(value: ObjectMinCardinality) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectMinCardinality(value))
+impl From<ObjectMinCardinality> for ClassExpression {
+    fn from(value: ObjectMinCardinality) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectMinCardinality(value))
+    }
+}
+
+#[pymethods]
+impl ObjectMinCardinality {
+    #[new]
+    fn new(n: u32, ope: ObjectPropertyExpression, bce: BoxWrap<ClassExpression>) -> Self {
+        ObjectMinCardinality { n, ope, bce }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("n".to_string(), "ope".to_string(), "bce".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "n" => self
+                .n
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "ope" => self
+                .ope
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "bce" => self
+                .bce
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectMinCardinality {
-        #[new]
-        fn new(n: u32,ope: ObjectPropertyExpression,bce: BoxWrap<ClassExpression>,) -> Self {
-            ObjectMinCardinality{
-                n,
-                ope,
-                bce,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String, String,)> {
-            Ok((
-            	"n".to_string(),
-            	"ope".to_string(),
-            	"bce".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"n" => self.n.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"bce" => self.bce.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "n" => {
+                self.n = value.extract()?;
+                Ok(())
             }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"n" => {
-                    self.n = value.extract()?;
+            "ope" => {
+                self.ope = value.extract()?;
                 Ok(())
-                },
-            	"ope" => {
-                    self.ope = value.extract()?;
-                Ok(())
-                },
-            	"bce" => {
-                    self.bce = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "bce" => {
+                self.bce = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4807,119 +4925,135 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectMinCardinality ********/
+#[pymethods]
+impl ObjectMinCardinality {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectMinCardinality ********/
-    #[pymethods]
-    impl ObjectMinCardinality {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectMaxCardinality for ClassExpression ****************/
-    #[doc = concat!("ObjectMaxCardinality(n: intope: ObjectPropertyExpressionbce: ClassExpression",
+/**************** ENUM VARIANT ObjectMaxCardinality for ClassExpression ****************/
+#[doc = concat!("ObjectMaxCardinality(n: intope: ObjectPropertyExpressionbce: ClassExpression",
         "\n\n",doc!(ObjectMaxCardinality))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectMaxCardinality{
-        #[doc="n: int"]
-        #[pyo3(get,set)]
-        pub n: u32,
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-        #[doc="bce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub bce: BoxWrap<ClassExpression>,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectMaxCardinality {
+    #[doc = "n: int"]
+    #[pyo3(get, set)]
+    pub n: u32,
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+    #[doc = "bce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub bce: BoxWrap<ClassExpression>,
+}
 
-    impl From<ObjectMaxCardinality> for ClassExpression {
-        fn from(value: ObjectMaxCardinality) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectMaxCardinality(value))
+impl From<ObjectMaxCardinality> for ClassExpression {
+    fn from(value: ObjectMaxCardinality) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectMaxCardinality(value))
+    }
+}
+
+#[pymethods]
+impl ObjectMaxCardinality {
+    #[new]
+    fn new(n: u32, ope: ObjectPropertyExpression, bce: BoxWrap<ClassExpression>) -> Self {
+        ObjectMaxCardinality { n, ope, bce }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("n".to_string(), "ope".to_string(), "bce".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "n" => self
+                .n
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "ope" => self
+                .ope
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "bce" => self
+                .bce
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectMaxCardinality {
-        #[new]
-        fn new(n: u32,ope: ObjectPropertyExpression,bce: BoxWrap<ClassExpression>,) -> Self {
-            ObjectMaxCardinality{
-                n,
-                ope,
-                bce,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String, String,)> {
-            Ok((
-            	"n".to_string(),
-            	"ope".to_string(),
-            	"bce".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"n" => self.n.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"bce" => self.bce.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "n" => {
+                self.n = value.extract()?;
+                Ok(())
             }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"n" => {
-                    self.n = value.extract()?;
+            "ope" => {
+                self.ope = value.extract()?;
                 Ok(())
-                },
-            	"ope" => {
-                    self.ope = value.extract()?;
-                Ok(())
-                },
-            	"bce" => {
-                    self.bce = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "bce" => {
+                self.bce = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -4932,119 +5066,135 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectMaxCardinality ********/
+#[pymethods]
+impl ObjectMaxCardinality {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectMaxCardinality ********/
-    #[pymethods]
-    impl ObjectMaxCardinality {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT ObjectExactCardinality for ClassExpression ****************/
-    #[doc = concat!("ObjectExactCardinality(n: intope: ObjectPropertyExpressionbce: ClassExpression",
+/**************** ENUM VARIANT ObjectExactCardinality for ClassExpression ****************/
+#[doc = concat!("ObjectExactCardinality(n: intope: ObjectPropertyExpressionbce: ClassExpression",
         "\n\n",doc!(ObjectExactCardinality))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectExactCardinality{
-        #[doc="n: int"]
-        #[pyo3(get,set)]
-        pub n: u32,
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-        #[doc="bce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub bce: BoxWrap<ClassExpression>,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectExactCardinality {
+    #[doc = "n: int"]
+    #[pyo3(get, set)]
+    pub n: u32,
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+    #[doc = "bce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub bce: BoxWrap<ClassExpression>,
+}
 
-    impl From<ObjectExactCardinality> for ClassExpression {
-        fn from(value: ObjectExactCardinality) -> Self {
-            ClassExpression(ClassExpression_Inner::ObjectExactCardinality(value))
+impl From<ObjectExactCardinality> for ClassExpression {
+    fn from(value: ObjectExactCardinality) -> Self {
+        ClassExpression(ClassExpression_Inner::ObjectExactCardinality(value))
+    }
+}
+
+#[pymethods]
+impl ObjectExactCardinality {
+    #[new]
+    fn new(n: u32, ope: ObjectPropertyExpression, bce: BoxWrap<ClassExpression>) -> Self {
+        ObjectExactCardinality { n, ope, bce }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("n".to_string(), "ope".to_string(), "bce".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "n" => self
+                .n
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "ope" => self
+                .ope
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "bce" => self
+                .bce
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectExactCardinality {
-        #[new]
-        fn new(n: u32,ope: ObjectPropertyExpression,bce: BoxWrap<ClassExpression>,) -> Self {
-            ObjectExactCardinality{
-                n,
-                ope,
-                bce,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String, String,)> {
-            Ok((
-            	"n".to_string(),
-            	"ope".to_string(),
-            	"bce".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"n" => self.n.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"bce" => self.bce.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "n" => {
+                self.n = value.extract()?;
+                Ok(())
             }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"n" => {
-                    self.n = value.extract()?;
+            "ope" => {
+                self.ope = value.extract()?;
                 Ok(())
-                },
-            	"ope" => {
-                    self.ope = value.extract()?;
-                Ok(())
-                },
-            	"bce" => {
-                    self.bce = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "bce" => {
+                self.bce = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5057,109 +5207,122 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for ObjectExactCardinality ********/
+#[pymethods]
+impl ObjectExactCardinality {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for ObjectExactCardinality ********/
-    #[pymethods]
-    impl ObjectExactCardinality {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT DataSomeValuesFrom for ClassExpression ****************/
-    #[doc = concat!("DataSomeValuesFrom(dp: DataPropertydr: DataRange",
+/**************** ENUM VARIANT DataSomeValuesFrom for ClassExpression ****************/
+#[doc = concat!("DataSomeValuesFrom(dp: DataPropertydr: DataRange",
         "\n\n",doc!(DataSomeValuesFrom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataSomeValuesFrom{
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-        #[doc="dr: DataRange"]
-        #[pyo3(get,set)]
-        pub dr: DataRange,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataSomeValuesFrom {
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+    #[doc = "dr: DataRange"]
+    #[pyo3(get, set)]
+    pub dr: DataRange,
+}
 
-    impl From<DataSomeValuesFrom> for ClassExpression {
-        fn from(value: DataSomeValuesFrom) -> Self {
-            ClassExpression(ClassExpression_Inner::DataSomeValuesFrom(value))
+impl From<DataSomeValuesFrom> for ClassExpression {
+    fn from(value: DataSomeValuesFrom) -> Self {
+        ClassExpression(ClassExpression_Inner::DataSomeValuesFrom(value))
+    }
+}
+
+#[pymethods]
+impl DataSomeValuesFrom {
+    #[new]
+    fn new(dp: DataProperty, dr: DataRange) -> Self {
+        DataSomeValuesFrom { dp, dr }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("dp".to_string(), "dr".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "dp" => self
+                .dp
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dr" => self
+                .dr
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataSomeValuesFrom {
-        #[new]
-        fn new(dp: DataProperty,dr: DataRange,) -> Self {
-            DataSomeValuesFrom{
-                dp,
-                dr,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"dp".to_string(),
-            	"dr".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dr" => self.dr.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"dp" => {
-                    self.dp = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "dp" => {
+                self.dp = value.extract()?;
                 Ok(())
-                },
-            	"dr" => {
-                    self.dr = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "dr" => {
+                self.dr = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5172,109 +5335,122 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for DataSomeValuesFrom ********/
+#[pymethods]
+impl DataSomeValuesFrom {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for DataSomeValuesFrom ********/
-    #[pymethods]
-    impl DataSomeValuesFrom {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT DataAllValuesFrom for ClassExpression ****************/
-    #[doc = concat!("DataAllValuesFrom(dp: DataPropertydr: DataRange",
+/**************** ENUM VARIANT DataAllValuesFrom for ClassExpression ****************/
+#[doc = concat!("DataAllValuesFrom(dp: DataPropertydr: DataRange",
         "\n\n",doc!(DataAllValuesFrom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataAllValuesFrom{
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-        #[doc="dr: DataRange"]
-        #[pyo3(get,set)]
-        pub dr: DataRange,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataAllValuesFrom {
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+    #[doc = "dr: DataRange"]
+    #[pyo3(get, set)]
+    pub dr: DataRange,
+}
 
-    impl From<DataAllValuesFrom> for ClassExpression {
-        fn from(value: DataAllValuesFrom) -> Self {
-            ClassExpression(ClassExpression_Inner::DataAllValuesFrom(value))
+impl From<DataAllValuesFrom> for ClassExpression {
+    fn from(value: DataAllValuesFrom) -> Self {
+        ClassExpression(ClassExpression_Inner::DataAllValuesFrom(value))
+    }
+}
+
+#[pymethods]
+impl DataAllValuesFrom {
+    #[new]
+    fn new(dp: DataProperty, dr: DataRange) -> Self {
+        DataAllValuesFrom { dp, dr }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("dp".to_string(), "dr".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "dp" => self
+                .dp
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dr" => self
+                .dr
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataAllValuesFrom {
-        #[new]
-        fn new(dp: DataProperty,dr: DataRange,) -> Self {
-            DataAllValuesFrom{
-                dp,
-                dr,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"dp".to_string(),
-            	"dr".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dr" => self.dr.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"dp" => {
-                    self.dp = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "dp" => {
+                self.dp = value.extract()?;
                 Ok(())
-                },
-            	"dr" => {
-                    self.dr = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "dr" => {
+                self.dr = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5287,109 +5463,122 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for DataAllValuesFrom ********/
+#[pymethods]
+impl DataAllValuesFrom {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for DataAllValuesFrom ********/
-    #[pymethods]
-    impl DataAllValuesFrom {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT DataHasValue for ClassExpression ****************/
-    #[doc = concat!("DataHasValue(dp: DataPropertyl: Literal",
+/**************** ENUM VARIANT DataHasValue for ClassExpression ****************/
+#[doc = concat!("DataHasValue(dp: DataPropertyl: Literal",
         "\n\n",doc!(DataHasValue))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataHasValue{
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-        #[doc="l: Literal"]
-        #[pyo3(get,set)]
-        pub l: Literal,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataHasValue {
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+    #[doc = "l: Literal"]
+    #[pyo3(get, set)]
+    pub l: Literal,
+}
 
-    impl From<DataHasValue> for ClassExpression {
-        fn from(value: DataHasValue) -> Self {
-            ClassExpression(ClassExpression_Inner::DataHasValue(value))
+impl From<DataHasValue> for ClassExpression {
+    fn from(value: DataHasValue) -> Self {
+        ClassExpression(ClassExpression_Inner::DataHasValue(value))
+    }
+}
+
+#[pymethods]
+impl DataHasValue {
+    #[new]
+    fn new(dp: DataProperty, l: Literal) -> Self {
+        DataHasValue { dp, l }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("dp".to_string(), "l".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "dp" => self
+                .dp
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "l" => self
+                .l
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataHasValue {
-        #[new]
-        fn new(dp: DataProperty,l: Literal,) -> Self {
-            DataHasValue{
-                dp,
-                l,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"dp".to_string(),
-            	"l".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"l" => self.l.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"dp" => {
-                    self.dp = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "dp" => {
+                self.dp = value.extract()?;
                 Ok(())
-                },
-            	"l" => {
-                    self.l = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "l" => {
+                self.l = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5402,119 +5591,135 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for DataHasValue ********/
+#[pymethods]
+impl DataHasValue {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for DataHasValue ********/
-    #[pymethods]
-    impl DataHasValue {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT DataMinCardinality for ClassExpression ****************/
-    #[doc = concat!("DataMinCardinality(n: intdp: DataPropertydr: DataRange",
+/**************** ENUM VARIANT DataMinCardinality for ClassExpression ****************/
+#[doc = concat!("DataMinCardinality(n: intdp: DataPropertydr: DataRange",
         "\n\n",doc!(DataMinCardinality))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataMinCardinality{
-        #[doc="n: int"]
-        #[pyo3(get,set)]
-        pub n: u32,
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-        #[doc="dr: DataRange"]
-        #[pyo3(get,set)]
-        pub dr: DataRange,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataMinCardinality {
+    #[doc = "n: int"]
+    #[pyo3(get, set)]
+    pub n: u32,
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+    #[doc = "dr: DataRange"]
+    #[pyo3(get, set)]
+    pub dr: DataRange,
+}
 
-    impl From<DataMinCardinality> for ClassExpression {
-        fn from(value: DataMinCardinality) -> Self {
-            ClassExpression(ClassExpression_Inner::DataMinCardinality(value))
+impl From<DataMinCardinality> for ClassExpression {
+    fn from(value: DataMinCardinality) -> Self {
+        ClassExpression(ClassExpression_Inner::DataMinCardinality(value))
+    }
+}
+
+#[pymethods]
+impl DataMinCardinality {
+    #[new]
+    fn new(n: u32, dp: DataProperty, dr: DataRange) -> Self {
+        DataMinCardinality { n, dp, dr }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("n".to_string(), "dp".to_string(), "dr".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "n" => self
+                .n
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dp" => self
+                .dp
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dr" => self
+                .dr
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataMinCardinality {
-        #[new]
-        fn new(n: u32,dp: DataProperty,dr: DataRange,) -> Self {
-            DataMinCardinality{
-                n,
-                dp,
-                dr,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String, String,)> {
-            Ok((
-            	"n".to_string(),
-            	"dp".to_string(),
-            	"dr".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"n" => self.n.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dr" => self.dr.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "n" => {
+                self.n = value.extract()?;
+                Ok(())
             }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"n" => {
-                    self.n = value.extract()?;
+            "dp" => {
+                self.dp = value.extract()?;
                 Ok(())
-                },
-            	"dp" => {
-                    self.dp = value.extract()?;
-                Ok(())
-                },
-            	"dr" => {
-                    self.dr = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "dr" => {
+                self.dr = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5527,119 +5732,135 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for DataMinCardinality ********/
+#[pymethods]
+impl DataMinCardinality {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for DataMinCardinality ********/
-    #[pymethods]
-    impl DataMinCardinality {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT DataMaxCardinality for ClassExpression ****************/
-    #[doc = concat!("DataMaxCardinality(n: intdp: DataPropertydr: DataRange",
+/**************** ENUM VARIANT DataMaxCardinality for ClassExpression ****************/
+#[doc = concat!("DataMaxCardinality(n: intdp: DataPropertydr: DataRange",
         "\n\n",doc!(DataMaxCardinality))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataMaxCardinality{
-        #[doc="n: int"]
-        #[pyo3(get,set)]
-        pub n: u32,
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-        #[doc="dr: DataRange"]
-        #[pyo3(get,set)]
-        pub dr: DataRange,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataMaxCardinality {
+    #[doc = "n: int"]
+    #[pyo3(get, set)]
+    pub n: u32,
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+    #[doc = "dr: DataRange"]
+    #[pyo3(get, set)]
+    pub dr: DataRange,
+}
 
-    impl From<DataMaxCardinality> for ClassExpression {
-        fn from(value: DataMaxCardinality) -> Self {
-            ClassExpression(ClassExpression_Inner::DataMaxCardinality(value))
+impl From<DataMaxCardinality> for ClassExpression {
+    fn from(value: DataMaxCardinality) -> Self {
+        ClassExpression(ClassExpression_Inner::DataMaxCardinality(value))
+    }
+}
+
+#[pymethods]
+impl DataMaxCardinality {
+    #[new]
+    fn new(n: u32, dp: DataProperty, dr: DataRange) -> Self {
+        DataMaxCardinality { n, dp, dr }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("n".to_string(), "dp".to_string(), "dr".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "n" => self
+                .n
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dp" => self
+                .dp
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dr" => self
+                .dr
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataMaxCardinality {
-        #[new]
-        fn new(n: u32,dp: DataProperty,dr: DataRange,) -> Self {
-            DataMaxCardinality{
-                n,
-                dp,
-                dr,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String, String,)> {
-            Ok((
-            	"n".to_string(),
-            	"dp".to_string(),
-            	"dr".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"n" => self.n.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dr" => self.dr.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "n" => {
+                self.n = value.extract()?;
+                Ok(())
             }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"n" => {
-                    self.n = value.extract()?;
+            "dp" => {
+                self.dp = value.extract()?;
                 Ok(())
-                },
-            	"dp" => {
-                    self.dp = value.extract()?;
-                Ok(())
-                },
-            	"dr" => {
-                    self.dr = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "dr" => {
+                self.dr = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5652,119 +5873,135 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for DataMaxCardinality ********/
+#[pymethods]
+impl DataMaxCardinality {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for DataMaxCardinality ********/
-    #[pymethods]
-    impl DataMaxCardinality {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
+    }
+}
 
-    /**************** ENUM VARIANT DataExactCardinality for ClassExpression ****************/
-    #[doc = concat!("DataExactCardinality(n: intdp: DataPropertydr: DataRange",
+/**************** ENUM VARIANT DataExactCardinality for ClassExpression ****************/
+#[doc = concat!("DataExactCardinality(n: intdp: DataPropertydr: DataRange",
         "\n\n",doc!(DataExactCardinality))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataExactCardinality{
-        #[doc="n: int"]
-        #[pyo3(get,set)]
-        pub n: u32,
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-        #[doc="dr: DataRange"]
-        #[pyo3(get,set)]
-        pub dr: DataRange,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataExactCardinality {
+    #[doc = "n: int"]
+    #[pyo3(get, set)]
+    pub n: u32,
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+    #[doc = "dr: DataRange"]
+    #[pyo3(get, set)]
+    pub dr: DataRange,
+}
 
-    impl From<DataExactCardinality> for ClassExpression {
-        fn from(value: DataExactCardinality) -> Self {
-            ClassExpression(ClassExpression_Inner::DataExactCardinality(value))
+impl From<DataExactCardinality> for ClassExpression {
+    fn from(value: DataExactCardinality) -> Self {
+        ClassExpression(ClassExpression_Inner::DataExactCardinality(value))
+    }
+}
+
+#[pymethods]
+impl DataExactCardinality {
+    #[new]
+    fn new(n: u32, dp: DataProperty, dr: DataRange) -> Self {
+        DataExactCardinality { n, dp, dr }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("n".to_string(), "dp".to_string(), "dr".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "n" => self
+                .n
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dp" => self
+                .dp
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "dr" => self
+                .dr
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataExactCardinality {
-        #[new]
-        fn new(n: u32,dp: DataProperty,dr: DataRange,) -> Self {
-            DataExactCardinality{
-                n,
-                dp,
-                dr,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String, String,)> {
-            Ok((
-            	"n".to_string(),
-            	"dp".to_string(),
-            	"dr".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"n" => self.n.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"dr" => self.dr.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "n" => {
+                self.n = value.extract()?;
+                Ok(())
             }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"n" => {
-                    self.n = value.extract()?;
+            "dp" => {
+                self.dp = value.extract()?;
                 Ok(())
-                },
-            	"dp" => {
-                    self.dp = value.extract()?;
-                Ok(())
-                },
-            	"dr" => {
-                    self.dr = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "dr" => {
+                self.dr = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::ClassExpression<ArcStr>>::into(Into::<ClassExpression>::into(
+            self.clone(),
+        ))
+        .as_functional()
+        .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -5777,100 +6014,166 @@ pub struct ClassExpression(ClassExpression_Inner);
         serialization: &str,
         prefix_mapping: Option<&crate::prefix_mapping::PrefixMapping>,
     ) -> PyResult<String> {
-        let value: horned_owl::model::ClassExpression<ArcStr> = Into::<ClassExpression>::into(self.clone()).into();
+        let value: horned_owl::model::ClassExpression<ArcStr> =
+            Into::<ClassExpression>::into(self.clone()).into();
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => crate::as_omn!(value, prefix_mapping),
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
+}
+
+/******** EXTENSION "class-expression" for DataExactCardinality ********/
+#[pymethods]
+impl DataExactCardinality {
+    fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
     }
 
-    
-    /******** EXTENSION "class-expression" for DataExactCardinality ********/
-    #[pymethods]
-    impl DataExactCardinality {
-        fn __and__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectIntersectionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectIntersectionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
-            let ce: ClassExpression = obj.extract()?;
-            Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
-        }
-
-        fn __invert__(&self) -> ObjectComplementOf {
-            ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
-        }
+    fn __or__(&self, obj: &Bound<'_, PyAny>) -> PyResult<ObjectUnionOf> {
+        let ce: ClassExpression = obj.extract()?;
+        Ok(ObjectUnionOf(vec![self.clone().into(), ce].into()))
     }
 
-    // Transparent variant implementation
-    impl From<Class> for ClassExpression {
-        fn from(value: Class) -> Self {
-            ClassExpression(ClassExpression_Inner::Class(value))
-        }
+    fn __invert__(&self) -> ObjectComplementOf {
+        ObjectComplementOf(Box::<ClassExpression>::new(self.clone().into()).into())
     }
+}
 
-
+// Transparent variant implementation
+impl From<Class> for ClassExpression {
+    fn from(value: Class) -> Self {
+        ClassExpression(ClassExpression_Inner::Class(value))
+    }
+}
 
 impl From<&horned_owl::model::ClassExpression<ArcStr>> for ClassExpression {
     fn from(value: &horned_owl::model::ClassExpression<ArcStr>) -> Self {
         match value {
-        		horned_owl::model::ClassExpression::Class::<ArcStr>(f0) =>
-                    ClassExpression(ClassExpression_Inner::Class(f0.into())),
-                horned_owl::model::ClassExpression::ObjectIntersectionOf::<ArcStr>(first) =>
-                    ClassExpression(ClassExpression_Inner::ObjectIntersectionOf(ObjectIntersectionOf((first).into(),))),
-                horned_owl::model::ClassExpression::ObjectUnionOf::<ArcStr>(first) =>
-                    ClassExpression(ClassExpression_Inner::ObjectUnionOf(ObjectUnionOf((first).into(),))),
-                horned_owl::model::ClassExpression::ObjectComplementOf::<ArcStr>(first) =>
-                    ClassExpression(ClassExpression_Inner::ObjectComplementOf(ObjectComplementOf((first).into(),))),
-                horned_owl::model::ClassExpression::ObjectOneOf::<ArcStr>(first) =>
-                    ClassExpression(ClassExpression_Inner::ObjectOneOf(ObjectOneOf((first).into(),))),horned_owl::model::ClassExpression::ObjectSomeValuesFrom::<ArcStr>{
-                    ope,
-bce
-                } => ClassExpression(ClassExpression_Inner::ObjectSomeValuesFrom(ObjectSomeValuesFrom{ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),})),horned_owl::model::ClassExpression::ObjectAllValuesFrom::<ArcStr>{
-                    ope,
-bce
-                } => ClassExpression(ClassExpression_Inner::ObjectAllValuesFrom(ObjectAllValuesFrom{ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),})),horned_owl::model::ClassExpression::ObjectHasValue::<ArcStr>{
-                    ope,
-i
-                } => ClassExpression(ClassExpression_Inner::ObjectHasValue(ObjectHasValue{ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),i: IntoCompatible::<Individual>::into_c(i),})),
-                horned_owl::model::ClassExpression::ObjectHasSelf::<ArcStr>(first) =>
-                    ClassExpression(ClassExpression_Inner::ObjectHasSelf(ObjectHasSelf((first).into(),))),horned_owl::model::ClassExpression::ObjectMinCardinality::<ArcStr>{
-                    n,
-ope,
-bce
-                } => ClassExpression(ClassExpression_Inner::ObjectMinCardinality(ObjectMinCardinality{n: IntoCompatible::<u32>::into_c(n),ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),})),horned_owl::model::ClassExpression::ObjectMaxCardinality::<ArcStr>{
-                    n,
-ope,
-bce
-                } => ClassExpression(ClassExpression_Inner::ObjectMaxCardinality(ObjectMaxCardinality{n: IntoCompatible::<u32>::into_c(n),ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),})),horned_owl::model::ClassExpression::ObjectExactCardinality::<ArcStr>{
-                    n,
-ope,
-bce
-                } => ClassExpression(ClassExpression_Inner::ObjectExactCardinality(ObjectExactCardinality{n: IntoCompatible::<u32>::into_c(n),ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),})),horned_owl::model::ClassExpression::DataSomeValuesFrom::<ArcStr>{
-                    dp,
-dr
-                } => ClassExpression(ClassExpression_Inner::DataSomeValuesFrom(DataSomeValuesFrom{dp: IntoCompatible::<DataProperty>::into_c(dp),dr: IntoCompatible::<DataRange>::into_c(dr),})),horned_owl::model::ClassExpression::DataAllValuesFrom::<ArcStr>{
-                    dp,
-dr
-                } => ClassExpression(ClassExpression_Inner::DataAllValuesFrom(DataAllValuesFrom{dp: IntoCompatible::<DataProperty>::into_c(dp),dr: IntoCompatible::<DataRange>::into_c(dr),})),horned_owl::model::ClassExpression::DataHasValue::<ArcStr>{
-                    dp,
-l
-                } => ClassExpression(ClassExpression_Inner::DataHasValue(DataHasValue{dp: IntoCompatible::<DataProperty>::into_c(dp),l: IntoCompatible::<Literal>::into_c(l),})),horned_owl::model::ClassExpression::DataMinCardinality::<ArcStr>{
-                    n,
-dp,
-dr
-                } => ClassExpression(ClassExpression_Inner::DataMinCardinality(DataMinCardinality{n: IntoCompatible::<u32>::into_c(n),dp: IntoCompatible::<DataProperty>::into_c(dp),dr: IntoCompatible::<DataRange>::into_c(dr),})),horned_owl::model::ClassExpression::DataMaxCardinality::<ArcStr>{
-                    n,
-dp,
-dr
-                } => ClassExpression(ClassExpression_Inner::DataMaxCardinality(DataMaxCardinality{n: IntoCompatible::<u32>::into_c(n),dp: IntoCompatible::<DataProperty>::into_c(dp),dr: IntoCompatible::<DataRange>::into_c(dr),})),horned_owl::model::ClassExpression::DataExactCardinality::<ArcStr>{
-                    n,
-dp,
-dr
-                } => ClassExpression(ClassExpression_Inner::DataExactCardinality(DataExactCardinality{n: IntoCompatible::<u32>::into_c(n),dp: IntoCompatible::<DataProperty>::into_c(dp),dr: IntoCompatible::<DataRange>::into_c(dr),})),
+            horned_owl::model::ClassExpression::Class::<ArcStr>(f0) => {
+                ClassExpression(ClassExpression_Inner::Class(f0.into()))
+            }
+            horned_owl::model::ClassExpression::ObjectIntersectionOf::<ArcStr>(first) => {
+                ClassExpression(ClassExpression_Inner::ObjectIntersectionOf(
+                    ObjectIntersectionOf((first).into()),
+                ))
+            }
+            horned_owl::model::ClassExpression::ObjectUnionOf::<ArcStr>(first) => ClassExpression(
+                ClassExpression_Inner::ObjectUnionOf(ObjectUnionOf((first).into())),
+            ),
+            horned_owl::model::ClassExpression::ObjectComplementOf::<ArcStr>(first) => {
+                ClassExpression(ClassExpression_Inner::ObjectComplementOf(
+                    ObjectComplementOf((first).into()),
+                ))
+            }
+            horned_owl::model::ClassExpression::ObjectOneOf::<ArcStr>(first) => ClassExpression(
+                ClassExpression_Inner::ObjectOneOf(ObjectOneOf((first).into())),
+            ),
+            horned_owl::model::ClassExpression::ObjectSomeValuesFrom::<ArcStr> { ope, bce } => {
+                ClassExpression(ClassExpression_Inner::ObjectSomeValuesFrom(
+                    ObjectSomeValuesFrom {
+                        ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),
+                        bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::ObjectAllValuesFrom::<ArcStr> { ope, bce } => {
+                ClassExpression(ClassExpression_Inner::ObjectAllValuesFrom(
+                    ObjectAllValuesFrom {
+                        ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),
+                        bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::ObjectHasValue::<ArcStr> { ope, i } => {
+                ClassExpression(ClassExpression_Inner::ObjectHasValue(ObjectHasValue {
+                    ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),
+                    i: IntoCompatible::<Individual>::into_c(i),
+                }))
+            }
+            horned_owl::model::ClassExpression::ObjectHasSelf::<ArcStr>(first) => ClassExpression(
+                ClassExpression_Inner::ObjectHasSelf(ObjectHasSelf((first).into())),
+            ),
+            horned_owl::model::ClassExpression::ObjectMinCardinality::<ArcStr> { n, ope, bce } => {
+                ClassExpression(ClassExpression_Inner::ObjectMinCardinality(
+                    ObjectMinCardinality {
+                        n: IntoCompatible::<u32>::into_c(n),
+                        ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),
+                        bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::ObjectMaxCardinality::<ArcStr> { n, ope, bce } => {
+                ClassExpression(ClassExpression_Inner::ObjectMaxCardinality(
+                    ObjectMaxCardinality {
+                        n: IntoCompatible::<u32>::into_c(n),
+                        ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),
+                        bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::ObjectExactCardinality::<ArcStr> {
+                n,
+                ope,
+                bce,
+            } => ClassExpression(ClassExpression_Inner::ObjectExactCardinality(
+                ObjectExactCardinality {
+                    n: IntoCompatible::<u32>::into_c(n),
+                    ope: IntoCompatible::<ObjectPropertyExpression>::into_c(ope),
+                    bce: IntoCompatible::<BoxWrap<ClassExpression>>::into_c(bce),
+                },
+            )),
+            horned_owl::model::ClassExpression::DataSomeValuesFrom::<ArcStr> { dp, dr } => {
+                ClassExpression(ClassExpression_Inner::DataSomeValuesFrom(
+                    DataSomeValuesFrom {
+                        dp: IntoCompatible::<DataProperty>::into_c(dp),
+                        dr: IntoCompatible::<DataRange>::into_c(dr),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::DataAllValuesFrom::<ArcStr> { dp, dr } => {
+                ClassExpression(ClassExpression_Inner::DataAllValuesFrom(
+                    DataAllValuesFrom {
+                        dp: IntoCompatible::<DataProperty>::into_c(dp),
+                        dr: IntoCompatible::<DataRange>::into_c(dr),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::DataHasValue::<ArcStr> { dp, l } => {
+                ClassExpression(ClassExpression_Inner::DataHasValue(DataHasValue {
+                    dp: IntoCompatible::<DataProperty>::into_c(dp),
+                    l: IntoCompatible::<Literal>::into_c(l),
+                }))
+            }
+            horned_owl::model::ClassExpression::DataMinCardinality::<ArcStr> { n, dp, dr } => {
+                ClassExpression(ClassExpression_Inner::DataMinCardinality(
+                    DataMinCardinality {
+                        n: IntoCompatible::<u32>::into_c(n),
+                        dp: IntoCompatible::<DataProperty>::into_c(dp),
+                        dr: IntoCompatible::<DataRange>::into_c(dr),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::DataMaxCardinality::<ArcStr> { n, dp, dr } => {
+                ClassExpression(ClassExpression_Inner::DataMaxCardinality(
+                    DataMaxCardinality {
+                        n: IntoCompatible::<u32>::into_c(n),
+                        dp: IntoCompatible::<DataProperty>::into_c(dp),
+                        dr: IntoCompatible::<DataRange>::into_c(dr),
+                    },
+                ))
+            }
+            horned_owl::model::ClassExpression::DataExactCardinality::<ArcStr> { n, dp, dr } => {
+                ClassExpression(ClassExpression_Inner::DataExactCardinality(
+                    DataExactCardinality {
+                        n: IntoCompatible::<u32>::into_c(n),
+                        dp: IntoCompatible::<DataProperty>::into_c(dp),
+                        dr: IntoCompatible::<DataRange>::into_c(dr),
+                    },
+                ))
+            }
         }
     }
 }
@@ -5878,105 +6181,104 @@ dr
 impl From<&ClassExpression> for horned_owl::model::ClassExpression<ArcStr> {
     fn from(value: &ClassExpression) -> Self {
         match value.0.borrow() {
-                ClassExpression_Inner::Class(f0) => horned_owl::model::ClassExpression::<ArcStr>::Class(f0.into()),
-                ClassExpression_Inner::ObjectIntersectionOf(ObjectIntersectionOf(first)) =>
-                horned_owl::model::ClassExpression::<ArcStr>::ObjectIntersectionOf(
-                    first.into_c(),
-                ),
-                ClassExpression_Inner::ObjectUnionOf(ObjectUnionOf(first)) =>
-                horned_owl::model::ClassExpression::<ArcStr>::ObjectUnionOf(
-                    first.into_c(),
-                ),
-                ClassExpression_Inner::ObjectComplementOf(ObjectComplementOf(first)) =>
-                horned_owl::model::ClassExpression::<ArcStr>::ObjectComplementOf(
-                    first.into_c(),
-                ),
-                ClassExpression_Inner::ObjectOneOf(ObjectOneOf(first)) =>
-                horned_owl::model::ClassExpression::<ArcStr>::ObjectOneOf(
-                    first.into_c(),
-                ),
-                ClassExpression_Inner::ObjectSomeValuesFrom(ObjectSomeValuesFrom{
-                    ope, bce
-                }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectSomeValuesFrom{
-                	ope: ope.into_c(),
-                	bce: bce.into_c(),
-                },
-                ClassExpression_Inner::ObjectAllValuesFrom(ObjectAllValuesFrom{
-                    ope, bce
-                }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectAllValuesFrom{
-                	ope: ope.into_c(),
-                	bce: bce.into_c(),
-                },
-                ClassExpression_Inner::ObjectHasValue(ObjectHasValue{
-                    ope, i
-                }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectHasValue{
-                	ope: ope.into_c(),
-                	i: i.into_c(),
-                },
-                ClassExpression_Inner::ObjectHasSelf(ObjectHasSelf(first)) =>
-                horned_owl::model::ClassExpression::<ArcStr>::ObjectHasSelf(
-                    first.into_c(),
-                ),
-                ClassExpression_Inner::ObjectMinCardinality(ObjectMinCardinality{
-                    n, ope, bce
-                }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectMinCardinality{
-                	n: n.into_c(),
-                	ope: ope.into_c(),
-                	bce: bce.into_c(),
-                },
-                ClassExpression_Inner::ObjectMaxCardinality(ObjectMaxCardinality{
-                    n, ope, bce
-                }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectMaxCardinality{
-                	n: n.into_c(),
-                	ope: ope.into_c(),
-                	bce: bce.into_c(),
-                },
-                ClassExpression_Inner::ObjectExactCardinality(ObjectExactCardinality{
-                    n, ope, bce
-                }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectExactCardinality{
-                	n: n.into_c(),
-                	ope: ope.into_c(),
-                	bce: bce.into_c(),
-                },
-                ClassExpression_Inner::DataSomeValuesFrom(DataSomeValuesFrom{
-                    dp, dr
-                }) => horned_owl::model::ClassExpression::<ArcStr>::DataSomeValuesFrom{
-                	dp: dp.into_c(),
-                	dr: dr.into_c(),
-                },
-                ClassExpression_Inner::DataAllValuesFrom(DataAllValuesFrom{
-                    dp, dr
-                }) => horned_owl::model::ClassExpression::<ArcStr>::DataAllValuesFrom{
-                	dp: dp.into_c(),
-                	dr: dr.into_c(),
-                },
-                ClassExpression_Inner::DataHasValue(DataHasValue{
-                    dp, l
-                }) => horned_owl::model::ClassExpression::<ArcStr>::DataHasValue{
-                	dp: dp.into_c(),
-                	l: l.into_c(),
-                },
-                ClassExpression_Inner::DataMinCardinality(DataMinCardinality{
-                    n, dp, dr
-                }) => horned_owl::model::ClassExpression::<ArcStr>::DataMinCardinality{
-                	n: n.into_c(),
-                	dp: dp.into_c(),
-                	dr: dr.into_c(),
-                },
-                ClassExpression_Inner::DataMaxCardinality(DataMaxCardinality{
-                    n, dp, dr
-                }) => horned_owl::model::ClassExpression::<ArcStr>::DataMaxCardinality{
-                	n: n.into_c(),
-                	dp: dp.into_c(),
-                	dr: dr.into_c(),
-                },
-                ClassExpression_Inner::DataExactCardinality(DataExactCardinality{
-                    n, dp, dr
-                }) => horned_owl::model::ClassExpression::<ArcStr>::DataExactCardinality{
-                	n: n.into_c(),
-                	dp: dp.into_c(),
-                	dr: dr.into_c(),
-                },
+            ClassExpression_Inner::Class(f0) => {
+                horned_owl::model::ClassExpression::<ArcStr>::Class(f0.into())
+            }
+            ClassExpression_Inner::ObjectIntersectionOf(ObjectIntersectionOf(first)) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectIntersectionOf(first.into_c())
+            }
+            ClassExpression_Inner::ObjectUnionOf(ObjectUnionOf(first)) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectUnionOf(first.into_c())
+            }
+            ClassExpression_Inner::ObjectComplementOf(ObjectComplementOf(first)) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectComplementOf(first.into_c())
+            }
+            ClassExpression_Inner::ObjectOneOf(ObjectOneOf(first)) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectOneOf(first.into_c())
+            }
+            ClassExpression_Inner::ObjectSomeValuesFrom(ObjectSomeValuesFrom { ope, bce }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectSomeValuesFrom {
+                    ope: ope.into_c(),
+                    bce: bce.into_c(),
+                }
+            }
+            ClassExpression_Inner::ObjectAllValuesFrom(ObjectAllValuesFrom { ope, bce }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectAllValuesFrom {
+                    ope: ope.into_c(),
+                    bce: bce.into_c(),
+                }
+            }
+            ClassExpression_Inner::ObjectHasValue(ObjectHasValue { ope, i }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectHasValue {
+                    ope: ope.into_c(),
+                    i: i.into_c(),
+                }
+            }
+            ClassExpression_Inner::ObjectHasSelf(ObjectHasSelf(first)) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectHasSelf(first.into_c())
+            }
+            ClassExpression_Inner::ObjectMinCardinality(ObjectMinCardinality { n, ope, bce }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectMinCardinality {
+                    n: n.into_c(),
+                    ope: ope.into_c(),
+                    bce: bce.into_c(),
+                }
+            }
+            ClassExpression_Inner::ObjectMaxCardinality(ObjectMaxCardinality { n, ope, bce }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::ObjectMaxCardinality {
+                    n: n.into_c(),
+                    ope: ope.into_c(),
+                    bce: bce.into_c(),
+                }
+            }
+            ClassExpression_Inner::ObjectExactCardinality(ObjectExactCardinality {
+                n,
+                ope,
+                bce,
+            }) => horned_owl::model::ClassExpression::<ArcStr>::ObjectExactCardinality {
+                n: n.into_c(),
+                ope: ope.into_c(),
+                bce: bce.into_c(),
+            },
+            ClassExpression_Inner::DataSomeValuesFrom(DataSomeValuesFrom { dp, dr }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::DataSomeValuesFrom {
+                    dp: dp.into_c(),
+                    dr: dr.into_c(),
+                }
+            }
+            ClassExpression_Inner::DataAllValuesFrom(DataAllValuesFrom { dp, dr }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::DataAllValuesFrom {
+                    dp: dp.into_c(),
+                    dr: dr.into_c(),
+                }
+            }
+            ClassExpression_Inner::DataHasValue(DataHasValue { dp, l }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::DataHasValue {
+                    dp: dp.into_c(),
+                    l: l.into_c(),
+                }
+            }
+            ClassExpression_Inner::DataMinCardinality(DataMinCardinality { n, dp, dr }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::DataMinCardinality {
+                    n: n.into_c(),
+                    dp: dp.into_c(),
+                    dr: dr.into_c(),
+                }
+            }
+            ClassExpression_Inner::DataMaxCardinality(DataMaxCardinality { n, dp, dr }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::DataMaxCardinality {
+                    n: n.into_c(),
+                    dp: dp.into_c(),
+                    dr: dr.into_c(),
+                }
+            }
+            ClassExpression_Inner::DataExactCardinality(DataExactCardinality { n, dp, dr }) => {
+                horned_owl::model::ClassExpression::<ArcStr>::DataExactCardinality {
+                    n: n.into_c(),
+                    dp: dp.into_c(),
+                    dr: dr.into_c(),
+                }
+            }
         }
     }
 }
@@ -5988,216 +6290,205 @@ impl<'py> IntoPyObject<'py> for ClassExpression {
 
     fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
-            
-                ClassExpression_Inner::Class(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectIntersectionOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectUnionOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectComplementOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectOneOf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectSomeValuesFrom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectAllValuesFrom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectHasValue(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectHasSelf(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectMinCardinality(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectMaxCardinality(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::ObjectExactCardinality(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::DataSomeValuesFrom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::DataAllValuesFrom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::DataHasValue(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::DataMinCardinality(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::DataMaxCardinality(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                ClassExpression_Inner::DataExactCardinality(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
+            ClassExpression_Inner::Class(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            ClassExpression_Inner::ObjectIntersectionOf(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectUnionOf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            ClassExpression_Inner::ObjectComplementOf(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectOneOf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            ClassExpression_Inner::ObjectSomeValuesFrom(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectAllValuesFrom(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectHasValue(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectHasSelf(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            ClassExpression_Inner::ObjectMinCardinality(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectMaxCardinality(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::ObjectExactCardinality(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::DataSomeValuesFrom(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::DataAllValuesFrom(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::DataHasValue(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            ClassExpression_Inner::DataMinCardinality(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::DataMaxCardinality(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
+
+            ClassExpression_Inner::DataExactCardinality(val) => {
+                val.into_pyobject(py).map(Bound::into_any)
+            }
         }
     }
-
 }
 
-impl <'py> FromPyObject<'_, 'py> for ClassExpression {
+impl<'py> FromPyObject<'_, 'py> for ClassExpression {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-            {
-            	let r = Class::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::Class(local);
-                    return Ok(ClassExpression(inner));
-                }
+        {
+            let r = Class::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::Class(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectIntersectionOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectIntersectionOf(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectIntersectionOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectIntersectionOf(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectUnionOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectUnionOf(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectUnionOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectUnionOf(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectComplementOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectComplementOf(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectComplementOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectComplementOf(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectOneOf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectOneOf(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectOneOf::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectOneOf(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectSomeValuesFrom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectSomeValuesFrom(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectSomeValuesFrom::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectSomeValuesFrom(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectAllValuesFrom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectAllValuesFrom(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectAllValuesFrom::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectAllValuesFrom(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectHasValue::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectHasValue(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectHasValue::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectHasValue(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectHasSelf::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectHasSelf(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectHasSelf::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectHasSelf(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectMinCardinality::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectMinCardinality(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectMinCardinality::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectMinCardinality(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectMaxCardinality::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectMaxCardinality(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectMaxCardinality::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectMaxCardinality(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = ObjectExactCardinality::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::ObjectExactCardinality(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = ObjectExactCardinality::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::ObjectExactCardinality(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = DataSomeValuesFrom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::DataSomeValuesFrom(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = DataSomeValuesFrom::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::DataSomeValuesFrom(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = DataAllValuesFrom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::DataAllValuesFrom(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = DataAllValuesFrom::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::DataAllValuesFrom(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = DataHasValue::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::DataHasValue(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = DataHasValue::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::DataHasValue(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = DataMinCardinality::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::DataMinCardinality(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = DataMinCardinality::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::DataMinCardinality(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = DataMaxCardinality::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::DataMaxCardinality(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = DataMaxCardinality::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::DataMaxCardinality(local);
+                return Ok(ClassExpression(inner));
             }
-            {
-                let r = DataExactCardinality::extract(ob);
-                if let Ok(local) = r {
-                    let inner = ClassExpression_Inner::DataExactCardinality(local);
-                    return Ok(ClassExpression(inner));
-                }
+        }
+        {
+            let r = DataExactCardinality::extract(ob);
+            if let Ok(local) = r {
+                let inner = ClassExpression_Inner::DataExactCardinality(local);
+                return Ok(ClassExpression(inner));
             }
+        }
 
-        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>("Object cannot be converted to ClassExpression"))
+        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Object cannot be converted to ClassExpression",
+        ))
     }
 }
 
@@ -6206,8 +6497,6 @@ impl ClassExpression {
         "typing.Union[m.Class,m.ObjectIntersectionOf,m.ObjectUnionOf,m.ObjectComplementOf,m.ObjectOneOf,m.ObjectSomeValuesFrom,m.ObjectAllValuesFrom,m.ObjectHasValue,m.ObjectHasSelf,m.ObjectMinCardinality,m.ObjectMaxCardinality,m.ObjectExactCardinality,m.DataSomeValuesFrom,m.DataAllValuesFrom,m.DataHasValue,m.DataMinCardinality,m.DataMaxCardinality,m.DataExactCardinality,]".into()
     }
 }
-
-
 
 /**************** Base implementations for ClassExpression ****************/
 impl FromCompatible<horned_owl::model::ClassExpression<ArcStr>> for ClassExpression {
@@ -6339,16 +6628,14 @@ impl FromCompatible<&Vec<horned_owl::model::ClassExpression<ArcStr>>> for VecWra
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum PropertyExpression {
-    
-        #[pyo3(transparent)]
-        ObjectPropertyExpression (ObjectPropertyExpression),
-    
-        #[pyo3(transparent)]
-        DataProperty (DataProperty),
-    
-        #[pyo3(transparent)]
-        AnnotationProperty (AnnotationProperty),
-    
+    #[pyo3(transparent)]
+    ObjectPropertyExpression(ObjectPropertyExpression),
+
+    #[pyo3(transparent)]
+    DataProperty(DataProperty),
+
+    #[pyo3(transparent)]
+    AnnotationProperty(AnnotationProperty),
 }
 
 impl<'py> IntoPyObject<'py> for PropertyExpression {
@@ -6358,13 +6645,15 @@ impl<'py> IntoPyObject<'py> for PropertyExpression {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
-            PropertyExpression::ObjectPropertyExpression(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+            PropertyExpression::ObjectPropertyExpression(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             PropertyExpression::DataProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            PropertyExpression::AnnotationProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            PropertyExpression::AnnotationProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
         }
     }
 }
@@ -6372,40 +6661,44 @@ impl<'py> IntoPyObject<'py> for PropertyExpression {
 impl From<&PropertyExpression> for horned_owl::model::PropertyExpression<ArcStr> {
     fn from(value: &PropertyExpression) -> Self {
         match value {
-        
-            PropertyExpression::ObjectPropertyExpression(inner) => horned_owl::model::PropertyExpression::ObjectPropertyExpression(inner.into()),
-        
-            PropertyExpression::DataProperty(inner) => horned_owl::model::PropertyExpression::DataProperty(inner.into()),
-        
-            PropertyExpression::AnnotationProperty(inner) => horned_owl::model::PropertyExpression::AnnotationProperty(inner.into()),
-        
+            PropertyExpression::ObjectPropertyExpression(inner) => {
+                horned_owl::model::PropertyExpression::ObjectPropertyExpression(inner.into())
+            }
+
+            PropertyExpression::DataProperty(inner) => {
+                horned_owl::model::PropertyExpression::DataProperty(inner.into())
+            }
+
+            PropertyExpression::AnnotationProperty(inner) => {
+                horned_owl::model::PropertyExpression::AnnotationProperty(inner.into())
+            }
         }
     }
 }
 
 impl From<&horned_owl::model::PropertyExpression<ArcStr>> for PropertyExpression {
-
     fn from(value: &horned_owl::model::PropertyExpression<ArcStr>) -> Self {
         match value {
-        
-            horned_owl::model::PropertyExpression::ObjectPropertyExpression(inner) => PropertyExpression::ObjectPropertyExpression(inner.into()),
-        
-            horned_owl::model::PropertyExpression::DataProperty(inner) => PropertyExpression::DataProperty(inner.into()),
-        
-            horned_owl::model::PropertyExpression::AnnotationProperty(inner) => PropertyExpression::AnnotationProperty(inner.into()),
-        
+            horned_owl::model::PropertyExpression::ObjectPropertyExpression(inner) => {
+                PropertyExpression::ObjectPropertyExpression(inner.into())
+            }
+
+            horned_owl::model::PropertyExpression::DataProperty(inner) => {
+                PropertyExpression::DataProperty(inner.into())
+            }
+
+            horned_owl::model::PropertyExpression::AnnotationProperty(inner) => {
+                PropertyExpression::AnnotationProperty(inner.into())
+            }
         }
     }
 }
-
 
 impl PropertyExpression {
     pub fn py_def() -> String {
         "typing.Union[m.ObjectPropertyExpression,m.DataProperty,m.AnnotationProperty,]".into()
     }
 }
-
-
 
 /**************** Base implementations for PropertyExpression ****************/
 impl FromCompatible<horned_owl::model::PropertyExpression<ArcStr>> for PropertyExpression {
@@ -6495,55 +6788,69 @@ impl From<&Vec<horned_owl::model::PropertyExpression<ArcStr>>> for VecWrap<Prope
     }
 }
 
-impl FromCompatible<&BoxWrap<PropertyExpression>> for Box<horned_owl::model::PropertyExpression<ArcStr>> {
+impl FromCompatible<&BoxWrap<PropertyExpression>>
+    for Box<horned_owl::model::PropertyExpression<ArcStr>>
+{
     fn from_c(value: &BoxWrap<PropertyExpression>) -> Self {
         Box::<horned_owl::model::PropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::PropertyExpression<ArcStr>>> for BoxWrap<PropertyExpression> {
+impl FromCompatible<&Box<horned_owl::model::PropertyExpression<ArcStr>>>
+    for BoxWrap<PropertyExpression>
+{
     fn from_c(value: &Box<horned_owl::model::PropertyExpression<ArcStr>>) -> Self {
         BoxWrap::<PropertyExpression>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<PropertyExpression>> for Box<horned_owl::model::PropertyExpression<ArcStr>> {
+impl FromCompatible<BoxWrap<PropertyExpression>>
+    for Box<horned_owl::model::PropertyExpression<ArcStr>>
+{
     fn from_c(value: BoxWrap<PropertyExpression>) -> Self {
         Box::<horned_owl::model::PropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::PropertyExpression<ArcStr>>> for BoxWrap<PropertyExpression> {
+impl FromCompatible<Box<horned_owl::model::PropertyExpression<ArcStr>>>
+    for BoxWrap<PropertyExpression>
+{
     fn from_c(value: Box<horned_owl::model::PropertyExpression<ArcStr>>) -> Self {
         BoxWrap::<PropertyExpression>::from(value)
     }
 }
-impl FromCompatible<VecWrap<PropertyExpression>> for Vec<horned_owl::model::PropertyExpression<ArcStr>> {
+impl FromCompatible<VecWrap<PropertyExpression>>
+    for Vec<horned_owl::model::PropertyExpression<ArcStr>>
+{
     fn from_c(value: VecWrap<PropertyExpression>) -> Self {
         Vec::<horned_owl::model::PropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::PropertyExpression<ArcStr>>> for VecWrap<PropertyExpression> {
+impl FromCompatible<Vec<horned_owl::model::PropertyExpression<ArcStr>>>
+    for VecWrap<PropertyExpression>
+{
     fn from_c(value: Vec<horned_owl::model::PropertyExpression<ArcStr>>) -> Self {
         VecWrap::<PropertyExpression>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<PropertyExpression>> for Vec<horned_owl::model::PropertyExpression<ArcStr>> {
+impl FromCompatible<&VecWrap<PropertyExpression>>
+    for Vec<horned_owl::model::PropertyExpression<ArcStr>>
+{
     fn from_c(value: &VecWrap<PropertyExpression>) -> Self {
         Vec::<horned_owl::model::PropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::PropertyExpression<ArcStr>>> for VecWrap<PropertyExpression> {
+impl FromCompatible<&Vec<horned_owl::model::PropertyExpression<ArcStr>>>
+    for VecWrap<PropertyExpression>
+{
     fn from_c(value: &Vec<horned_owl::model::PropertyExpression<ArcStr>>) -> Self {
         VecWrap::<PropertyExpression>::from(value)
     }
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AnnotationSubject {
-    
-        #[pyo3(transparent)]
-        IRI (IRI),
-    
-        #[pyo3(transparent)]
-        AnonymousIndividual (AnonymousIndividual),
-    
+    #[pyo3(transparent)]
+    IRI(IRI),
+
+    #[pyo3(transparent)]
+    AnonymousIndividual(AnonymousIndividual),
 }
 
 impl<'py> IntoPyObject<'py> for AnnotationSubject {
@@ -6553,11 +6860,11 @@ impl<'py> IntoPyObject<'py> for AnnotationSubject {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
             AnnotationSubject::IRI(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            AnnotationSubject::AnonymousIndividual(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            AnnotationSubject::AnonymousIndividual(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
         }
     }
 }
@@ -6565,36 +6872,36 @@ impl<'py> IntoPyObject<'py> for AnnotationSubject {
 impl From<&AnnotationSubject> for horned_owl::model::AnnotationSubject<ArcStr> {
     fn from(value: &AnnotationSubject) -> Self {
         match value {
-        
-            AnnotationSubject::IRI(inner) => horned_owl::model::AnnotationSubject::IRI(inner.into()),
-        
-            AnnotationSubject::AnonymousIndividual(inner) => horned_owl::model::AnnotationSubject::AnonymousIndividual(inner.into()),
-        
+            AnnotationSubject::IRI(inner) => {
+                horned_owl::model::AnnotationSubject::IRI(inner.into())
+            }
+
+            AnnotationSubject::AnonymousIndividual(inner) => {
+                horned_owl::model::AnnotationSubject::AnonymousIndividual(inner.into())
+            }
         }
     }
 }
 
 impl From<&horned_owl::model::AnnotationSubject<ArcStr>> for AnnotationSubject {
-
     fn from(value: &horned_owl::model::AnnotationSubject<ArcStr>) -> Self {
         match value {
-        
-            horned_owl::model::AnnotationSubject::IRI(inner) => AnnotationSubject::IRI(inner.into()),
-        
-            horned_owl::model::AnnotationSubject::AnonymousIndividual(inner) => AnnotationSubject::AnonymousIndividual(inner.into()),
-        
+            horned_owl::model::AnnotationSubject::IRI(inner) => {
+                AnnotationSubject::IRI(inner.into())
+            }
+
+            horned_owl::model::AnnotationSubject::AnonymousIndividual(inner) => {
+                AnnotationSubject::AnonymousIndividual(inner.into())
+            }
         }
     }
 }
-
 
 impl AnnotationSubject {
     pub fn py_def() -> String {
         "typing.Union[m.IRI,m.AnonymousIndividual,]".into()
     }
 }
-
-
 
 /**************** Base implementations for AnnotationSubject ****************/
 impl FromCompatible<horned_owl::model::AnnotationSubject<ArcStr>> for AnnotationSubject {
@@ -6684,42 +6991,58 @@ impl From<&Vec<horned_owl::model::AnnotationSubject<ArcStr>>> for VecWrap<Annota
     }
 }
 
-impl FromCompatible<&BoxWrap<AnnotationSubject>> for Box<horned_owl::model::AnnotationSubject<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnnotationSubject>>
+    for Box<horned_owl::model::AnnotationSubject<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnnotationSubject>) -> Self {
         Box::<horned_owl::model::AnnotationSubject<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnnotationSubject<ArcStr>>> for BoxWrap<AnnotationSubject> {
+impl FromCompatible<&Box<horned_owl::model::AnnotationSubject<ArcStr>>>
+    for BoxWrap<AnnotationSubject>
+{
     fn from_c(value: &Box<horned_owl::model::AnnotationSubject<ArcStr>>) -> Self {
         BoxWrap::<AnnotationSubject>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnnotationSubject>> for Box<horned_owl::model::AnnotationSubject<ArcStr>> {
+impl FromCompatible<BoxWrap<AnnotationSubject>>
+    for Box<horned_owl::model::AnnotationSubject<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnnotationSubject>) -> Self {
         Box::<horned_owl::model::AnnotationSubject<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnnotationSubject<ArcStr>>> for BoxWrap<AnnotationSubject> {
+impl FromCompatible<Box<horned_owl::model::AnnotationSubject<ArcStr>>>
+    for BoxWrap<AnnotationSubject>
+{
     fn from_c(value: Box<horned_owl::model::AnnotationSubject<ArcStr>>) -> Self {
         BoxWrap::<AnnotationSubject>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnnotationSubject>> for Vec<horned_owl::model::AnnotationSubject<ArcStr>> {
+impl FromCompatible<VecWrap<AnnotationSubject>>
+    for Vec<horned_owl::model::AnnotationSubject<ArcStr>>
+{
     fn from_c(value: VecWrap<AnnotationSubject>) -> Self {
         Vec::<horned_owl::model::AnnotationSubject<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnnotationSubject<ArcStr>>> for VecWrap<AnnotationSubject> {
+impl FromCompatible<Vec<horned_owl::model::AnnotationSubject<ArcStr>>>
+    for VecWrap<AnnotationSubject>
+{
     fn from_c(value: Vec<horned_owl::model::AnnotationSubject<ArcStr>>) -> Self {
         VecWrap::<AnnotationSubject>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnnotationSubject>> for Vec<horned_owl::model::AnnotationSubject<ArcStr>> {
+impl FromCompatible<&VecWrap<AnnotationSubject>>
+    for Vec<horned_owl::model::AnnotationSubject<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnnotationSubject>) -> Self {
         Vec::<horned_owl::model::AnnotationSubject<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnnotationSubject<ArcStr>>> for VecWrap<AnnotationSubject> {
+impl FromCompatible<&Vec<horned_owl::model::AnnotationSubject<ArcStr>>>
+    for VecWrap<AnnotationSubject>
+{
     fn from_c(value: &Vec<horned_owl::model::AnnotationSubject<ArcStr>>) -> Self {
         VecWrap::<AnnotationSubject>::from(value)
     }
@@ -6729,26 +7052,24 @@ impl FromCompatible<&Vec<horned_owl::model::AnnotationSubject<ArcStr>>> for VecW
     "\n\n",
     doc!(AnnotationProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AnnotationProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct AnnotationProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl AnnotationProperty {
     #[new]
-    fn new(first: IRI,) -> Self {
-        AnnotationProperty (first,)
+    fn new(first: IRI) -> Self {
+        AnnotationProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -6761,9 +7082,10 @@ impl AnnotationProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::AnnotationProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::AnnotationProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -6783,7 +7105,9 @@ impl AnnotationProperty {
 
         Ok(match crate::snippet::parse_syntax(serialization)? {
             crate::snippet::SnippetSyntax::Manchester => {
-                return Err(crate::snippet::no_manchester_rendering("AnnotationProperty"))
+                return Err(crate::snippet::no_manchester_rendering(
+                    "AnnotationProperty",
+                ))
             }
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
@@ -6792,22 +7116,15 @@ impl AnnotationProperty {
 
 impl From<&horned_owl::model::AnnotationProperty<ArcStr>> for AnnotationProperty {
     fn from(value: &horned_owl::model::AnnotationProperty<ArcStr>) -> Self {
-
-        AnnotationProperty (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        AnnotationProperty(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&AnnotationProperty> for horned_owl::model::AnnotationProperty<ArcStr> {
     fn from(value: &AnnotationProperty) -> Self {
-        horned_owl::model::AnnotationProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::AnnotationProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for AnnotationProperty ****************/
 impl FromCompatible<horned_owl::model::AnnotationProperty<ArcStr>> for AnnotationProperty {
@@ -6897,58 +7214,72 @@ impl From<&Vec<horned_owl::model::AnnotationProperty<ArcStr>>> for VecWrap<Annot
     }
 }
 
-impl FromCompatible<&BoxWrap<AnnotationProperty>> for Box<horned_owl::model::AnnotationProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnnotationProperty>>
+    for Box<horned_owl::model::AnnotationProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnnotationProperty>) -> Self {
         Box::<horned_owl::model::AnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnnotationProperty<ArcStr>>> for BoxWrap<AnnotationProperty> {
+impl FromCompatible<&Box<horned_owl::model::AnnotationProperty<ArcStr>>>
+    for BoxWrap<AnnotationProperty>
+{
     fn from_c(value: &Box<horned_owl::model::AnnotationProperty<ArcStr>>) -> Self {
         BoxWrap::<AnnotationProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnnotationProperty>> for Box<horned_owl::model::AnnotationProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<AnnotationProperty>>
+    for Box<horned_owl::model::AnnotationProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnnotationProperty>) -> Self {
         Box::<horned_owl::model::AnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnnotationProperty<ArcStr>>> for BoxWrap<AnnotationProperty> {
+impl FromCompatible<Box<horned_owl::model::AnnotationProperty<ArcStr>>>
+    for BoxWrap<AnnotationProperty>
+{
     fn from_c(value: Box<horned_owl::model::AnnotationProperty<ArcStr>>) -> Self {
         BoxWrap::<AnnotationProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnnotationProperty>> for Vec<horned_owl::model::AnnotationProperty<ArcStr>> {
+impl FromCompatible<VecWrap<AnnotationProperty>>
+    for Vec<horned_owl::model::AnnotationProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<AnnotationProperty>) -> Self {
         Vec::<horned_owl::model::AnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnnotationProperty<ArcStr>>> for VecWrap<AnnotationProperty> {
+impl FromCompatible<Vec<horned_owl::model::AnnotationProperty<ArcStr>>>
+    for VecWrap<AnnotationProperty>
+{
     fn from_c(value: Vec<horned_owl::model::AnnotationProperty<ArcStr>>) -> Self {
         VecWrap::<AnnotationProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnnotationProperty>> for Vec<horned_owl::model::AnnotationProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<AnnotationProperty>>
+    for Vec<horned_owl::model::AnnotationProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnnotationProperty>) -> Self {
         Vec::<horned_owl::model::AnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnnotationProperty<ArcStr>>> for VecWrap<AnnotationProperty> {
+impl FromCompatible<&Vec<horned_owl::model::AnnotationProperty<ArcStr>>>
+    for VecWrap<AnnotationProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::AnnotationProperty<ArcStr>>) -> Self {
         VecWrap::<AnnotationProperty>::from(value)
     }
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum AnnotationValue {
-    
-        #[pyo3(transparent)]
-        Literal (Literal),
-    
-        #[pyo3(transparent)]
-        IRI (IRI),
-    
-        #[pyo3(transparent)]
-        AnonymousIndividual (AnonymousIndividual),
-    
+    #[pyo3(transparent)]
+    Literal(Literal),
+
+    #[pyo3(transparent)]
+    IRI(IRI),
+
+    #[pyo3(transparent)]
+    AnonymousIndividual(AnonymousIndividual),
 }
 
 impl<'py> IntoPyObject<'py> for AnnotationValue {
@@ -6958,13 +7289,13 @@ impl<'py> IntoPyObject<'py> for AnnotationValue {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
             AnnotationValue::Literal(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             AnnotationValue::IRI(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            AnnotationValue::AnonymousIndividual(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            AnnotationValue::AnonymousIndividual(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
         }
     }
 }
@@ -6972,40 +7303,40 @@ impl<'py> IntoPyObject<'py> for AnnotationValue {
 impl From<&AnnotationValue> for horned_owl::model::AnnotationValue<ArcStr> {
     fn from(value: &AnnotationValue) -> Self {
         match value {
-        
-            AnnotationValue::Literal(inner) => horned_owl::model::AnnotationValue::Literal(inner.into()),
-        
+            AnnotationValue::Literal(inner) => {
+                horned_owl::model::AnnotationValue::Literal(inner.into())
+            }
+
             AnnotationValue::IRI(inner) => horned_owl::model::AnnotationValue::IRI(inner.into()),
-        
-            AnnotationValue::AnonymousIndividual(inner) => horned_owl::model::AnnotationValue::AnonymousIndividual(inner.into()),
-        
+
+            AnnotationValue::AnonymousIndividual(inner) => {
+                horned_owl::model::AnnotationValue::AnonymousIndividual(inner.into())
+            }
         }
     }
 }
 
 impl From<&horned_owl::model::AnnotationValue<ArcStr>> for AnnotationValue {
-
     fn from(value: &horned_owl::model::AnnotationValue<ArcStr>) -> Self {
         match value {
-        
-            horned_owl::model::AnnotationValue::Literal(inner) => AnnotationValue::Literal(inner.into()),
-        
+            horned_owl::model::AnnotationValue::Literal(inner) => {
+                AnnotationValue::Literal(inner.into())
+            }
+
             horned_owl::model::AnnotationValue::IRI(inner) => AnnotationValue::IRI(inner.into()),
-        
-            horned_owl::model::AnnotationValue::AnonymousIndividual(inner) => AnnotationValue::AnonymousIndividual(inner.into()),
-        
+
+            horned_owl::model::AnnotationValue::AnonymousIndividual(inner) => {
+                AnnotationValue::AnonymousIndividual(inner.into())
+            }
         }
     }
 }
-
 
 impl AnnotationValue {
     pub fn py_def() -> String {
         "typing.Union[m.Literal,m.IRI,m.AnonymousIndividual,]".into()
     }
 }
-
-
 
 /**************** Base implementations for AnnotationValue ****************/
 impl FromCompatible<horned_owl::model::AnnotationValue<ArcStr>> for AnnotationValue {
@@ -7139,40 +7470,32 @@ impl FromCompatible<&Vec<horned_owl::model::AnnotationValue<ArcStr>>> for VecWra
     "\n\n",
     doc!(Annotation)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Annotation {
-        #[doc="ap: AnnotationProperty"]
-        #[pyo3(get,set)]
-        pub ap: AnnotationProperty,
-    
-        #[doc="av: AnnotationValue"]
-        #[pyo3(get,set)]
-        pub av: AnnotationValue,
-    
-        #[doc="ann: typing.Set[Annotation]"]
-        #[pyo3(get,set)]
-        pub ann: BTreeSetWrap<Annotation>,
-    }
+    #[doc = "ap: AnnotationProperty"]
+    #[pyo3(get, set)]
+    pub ap: AnnotationProperty,
+
+    #[doc = "av: AnnotationValue"]
+    #[pyo3(get, set)]
+    pub av: AnnotationValue,
+
+    #[doc = "ann: typing.Set[Annotation]"]
+    #[pyo3(get, set)]
+    pub ann: BTreeSetWrap<Annotation>,
+}
 
 #[pymethods]
 impl Annotation {
     #[new]
-    fn new(ap: AnnotationProperty,av: AnnotationValue,ann: BTreeSetWrap<Annotation>,) -> Self {
-        Annotation {
-                ap,
-                av,
-                ann,
-        }
+    fn new(ap: AnnotationProperty, av: AnnotationValue, ann: BTreeSetWrap<Annotation>) -> Self {
+        Annotation { ap, av, ann }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String, String,)> {
-        Ok((
-            "ap".to_string(),
-            "av".to_string(),
-            "ann".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("ap".to_string(), "av".to_string(), "ann".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -7180,7 +7503,10 @@ impl Annotation {
             "ap" => self.ap.clone().into_pyobject(py).map(Bound::into_any),
             "av" => self.av.clone().into_pyobject(py).map(Bound::into_any),
             "ann" => self.ann.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -7189,16 +7515,19 @@ impl Annotation {
             "ap" => {
                 self.ap = value.extract()?;
                 Ok(())
-            },
+            }
             "av" => {
                 self.av = value.extract()?;
                 Ok(())
-            },
+            }
             "ann" => {
                 self.ann = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -7212,9 +7541,10 @@ impl Annotation {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::Annotation<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::Annotation<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -7251,7 +7581,6 @@ impl From<&horned_owl::model::Annotation<ArcStr>> for Annotation {
     }
 }
 
-
 impl From<&Annotation> for horned_owl::model::Annotation<ArcStr> {
     fn from(value: &Annotation) -> Self {
         horned_owl::model::Annotation::<ArcStr> {
@@ -7261,8 +7590,6 @@ impl From<&Annotation> for horned_owl::model::Annotation<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for Annotation ****************/
 impl FromCompatible<horned_owl::model::Annotation<ArcStr>> for Annotation {
@@ -7397,26 +7724,24 @@ impl FromCompatible<&Vec<horned_owl::model::Annotation<ArcStr>>> for VecWrap<Ann
     "\n\n",
     doc!(OntologyAnnotation)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct OntologyAnnotation (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct OntologyAnnotation(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub Annotation,
 );
 
 #[pymethods]
 impl OntologyAnnotation {
     #[new]
-    fn new(first: Annotation,) -> Self {
-        OntologyAnnotation (first,)
+    fn new(first: Annotation) -> Self {
+        OntologyAnnotation(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -7429,9 +7754,10 @@ impl OntologyAnnotation {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::OntologyAnnotation<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::OntologyAnnotation<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -7460,22 +7786,15 @@ impl OntologyAnnotation {
 
 impl From<&horned_owl::model::OntologyAnnotation<ArcStr>> for OntologyAnnotation {
     fn from(value: &horned_owl::model::OntologyAnnotation<ArcStr>) -> Self {
-
-        OntologyAnnotation (
-    IntoCompatible::<Annotation>::into_c(&value.0),
-        )
+        OntologyAnnotation(IntoCompatible::<Annotation>::into_c(&value.0))
     }
 }
 
 impl From<&OntologyAnnotation> for horned_owl::model::OntologyAnnotation<ArcStr> {
     fn from(value: &OntologyAnnotation) -> Self {
-        horned_owl::model::OntologyAnnotation::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::OntologyAnnotation::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for OntologyAnnotation ****************/
 impl FromCompatible<horned_owl::model::OntologyAnnotation<ArcStr>> for OntologyAnnotation {
@@ -7565,42 +7884,58 @@ impl From<&Vec<horned_owl::model::OntologyAnnotation<ArcStr>>> for VecWrap<Ontol
     }
 }
 
-impl FromCompatible<&BoxWrap<OntologyAnnotation>> for Box<horned_owl::model::OntologyAnnotation<ArcStr>> {
+impl FromCompatible<&BoxWrap<OntologyAnnotation>>
+    for Box<horned_owl::model::OntologyAnnotation<ArcStr>>
+{
     fn from_c(value: &BoxWrap<OntologyAnnotation>) -> Self {
         Box::<horned_owl::model::OntologyAnnotation<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::OntologyAnnotation<ArcStr>>> for BoxWrap<OntologyAnnotation> {
+impl FromCompatible<&Box<horned_owl::model::OntologyAnnotation<ArcStr>>>
+    for BoxWrap<OntologyAnnotation>
+{
     fn from_c(value: &Box<horned_owl::model::OntologyAnnotation<ArcStr>>) -> Self {
         BoxWrap::<OntologyAnnotation>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<OntologyAnnotation>> for Box<horned_owl::model::OntologyAnnotation<ArcStr>> {
+impl FromCompatible<BoxWrap<OntologyAnnotation>>
+    for Box<horned_owl::model::OntologyAnnotation<ArcStr>>
+{
     fn from_c(value: BoxWrap<OntologyAnnotation>) -> Self {
         Box::<horned_owl::model::OntologyAnnotation<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::OntologyAnnotation<ArcStr>>> for BoxWrap<OntologyAnnotation> {
+impl FromCompatible<Box<horned_owl::model::OntologyAnnotation<ArcStr>>>
+    for BoxWrap<OntologyAnnotation>
+{
     fn from_c(value: Box<horned_owl::model::OntologyAnnotation<ArcStr>>) -> Self {
         BoxWrap::<OntologyAnnotation>::from(value)
     }
 }
-impl FromCompatible<VecWrap<OntologyAnnotation>> for Vec<horned_owl::model::OntologyAnnotation<ArcStr>> {
+impl FromCompatible<VecWrap<OntologyAnnotation>>
+    for Vec<horned_owl::model::OntologyAnnotation<ArcStr>>
+{
     fn from_c(value: VecWrap<OntologyAnnotation>) -> Self {
         Vec::<horned_owl::model::OntologyAnnotation<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::OntologyAnnotation<ArcStr>>> for VecWrap<OntologyAnnotation> {
+impl FromCompatible<Vec<horned_owl::model::OntologyAnnotation<ArcStr>>>
+    for VecWrap<OntologyAnnotation>
+{
     fn from_c(value: Vec<horned_owl::model::OntologyAnnotation<ArcStr>>) -> Self {
         VecWrap::<OntologyAnnotation>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<OntologyAnnotation>> for Vec<horned_owl::model::OntologyAnnotation<ArcStr>> {
+impl FromCompatible<&VecWrap<OntologyAnnotation>>
+    for Vec<horned_owl::model::OntologyAnnotation<ArcStr>>
+{
     fn from_c(value: &VecWrap<OntologyAnnotation>) -> Self {
         Vec::<horned_owl::model::OntologyAnnotation<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::OntologyAnnotation<ArcStr>>> for VecWrap<OntologyAnnotation> {
+impl FromCompatible<&Vec<horned_owl::model::OntologyAnnotation<ArcStr>>>
+    for VecWrap<OntologyAnnotation>
+{
     fn from_c(value: &Vec<horned_owl::model::OntologyAnnotation<ArcStr>>) -> Self {
         VecWrap::<OntologyAnnotation>::from(value)
     }
@@ -7610,26 +7945,24 @@ impl FromCompatible<&Vec<horned_owl::model::OntologyAnnotation<ArcStr>>> for Vec
     "\n\n",
     doc!(Import)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Import (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct Import(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl Import {
     #[new]
-    fn new(first: IRI,) -> Self {
-        Import (first,)
+    fn new(first: IRI) -> Self {
+        Import(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -7642,9 +7975,10 @@ impl Import {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::Import<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::Import<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -7673,22 +8007,15 @@ impl Import {
 
 impl From<&horned_owl::model::Import<ArcStr>> for Import {
     fn from(value: &horned_owl::model::Import<ArcStr>) -> Self {
-
-        Import (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        Import(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&Import> for horned_owl::model::Import<ArcStr> {
     fn from(value: &Import) -> Self {
-        horned_owl::model::Import::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::Import::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for Import ****************/
 impl FromCompatible<horned_owl::model::Import<ArcStr>> for Import {
@@ -7823,26 +8150,24 @@ impl FromCompatible<&Vec<horned_owl::model::Import<ArcStr>>> for VecWrap<Import>
     "\n\n",
     doc!(DeclareClass)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeclareClass (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DeclareClass(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub Class,
 );
 
 #[pymethods]
 impl DeclareClass {
     #[new]
-    fn new(first: Class,) -> Self {
-        DeclareClass (first,)
+    fn new(first: Class) -> Self {
+        DeclareClass(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -7855,9 +8180,10 @@ impl DeclareClass {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DeclareClass<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DeclareClass<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -7886,22 +8212,15 @@ impl DeclareClass {
 
 impl From<&horned_owl::model::DeclareClass<ArcStr>> for DeclareClass {
     fn from(value: &horned_owl::model::DeclareClass<ArcStr>) -> Self {
-
-        DeclareClass (
-    IntoCompatible::<Class>::into_c(&value.0),
-        )
+        DeclareClass(IntoCompatible::<Class>::into_c(&value.0))
     }
 }
 
 impl From<&DeclareClass> for horned_owl::model::DeclareClass<ArcStr> {
     fn from(value: &DeclareClass) -> Self {
-        horned_owl::model::DeclareClass::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DeclareClass::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DeclareClass ****************/
 impl FromCompatible<horned_owl::model::DeclareClass<ArcStr>> for DeclareClass {
@@ -8036,26 +8355,24 @@ impl FromCompatible<&Vec<horned_owl::model::DeclareClass<ArcStr>>> for VecWrap<D
     "\n\n",
     doc!(DeclareObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeclareObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DeclareObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectProperty,
 );
 
 #[pymethods]
 impl DeclareObjectProperty {
     #[new]
-    fn new(first: ObjectProperty,) -> Self {
-        DeclareObjectProperty (first,)
+    fn new(first: ObjectProperty) -> Self {
+        DeclareObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -8068,9 +8385,10 @@ impl DeclareObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DeclareObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DeclareObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -8099,22 +8417,15 @@ impl DeclareObjectProperty {
 
 impl From<&horned_owl::model::DeclareObjectProperty<ArcStr>> for DeclareObjectProperty {
     fn from(value: &horned_owl::model::DeclareObjectProperty<ArcStr>) -> Self {
-
-        DeclareObjectProperty (
-    IntoCompatible::<ObjectProperty>::into_c(&value.0),
-        )
+        DeclareObjectProperty(IntoCompatible::<ObjectProperty>::into_c(&value.0))
     }
 }
 
 impl From<&DeclareObjectProperty> for horned_owl::model::DeclareObjectProperty<ArcStr> {
     fn from(value: &DeclareObjectProperty) -> Self {
-        horned_owl::model::DeclareObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DeclareObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DeclareObjectProperty ****************/
 impl FromCompatible<horned_owl::model::DeclareObjectProperty<ArcStr>> for DeclareObjectProperty {
@@ -8153,43 +8464,59 @@ impl From<DeclareObjectProperty> for horned_owl::model::DeclareObjectProperty<Ar
     }
 }
 
-impl From<&BoxWrap<DeclareObjectProperty>> for Box<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl From<&BoxWrap<DeclareObjectProperty>>
+    for Box<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<DeclareObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::DeclareObjectProperty<ArcStr>>> for BoxWrap<DeclareObjectProperty> {
+impl From<&Box<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for BoxWrap<DeclareObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<DeclareObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<DeclareObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<DeclareObjectProperty>> for Box<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl From<BoxWrap<DeclareObjectProperty>>
+    for Box<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<DeclareObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::DeclareObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::DeclareObjectProperty<ArcStr>>> for BoxWrap<DeclareObjectProperty> {
+impl From<Box<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for BoxWrap<DeclareObjectProperty>
+{
     fn from(value: Box<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<DeclareObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<DeclareObjectProperty>> for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl From<VecWrap<DeclareObjectProperty>>
+    for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<DeclareObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>> for VecWrap<DeclareObjectProperty> {
+impl From<Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for VecWrap<DeclareObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<DeclareObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<DeclareObjectProperty>> for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl From<&VecWrap<DeclareObjectProperty>>
+    for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<DeclareObjectProperty>) -> Self {
         value
             .0
@@ -8198,48 +8525,66 @@ impl From<&VecWrap<DeclareObjectProperty>> for Vec<horned_owl::model::DeclareObj
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>> for VecWrap<DeclareObjectProperty> {
+impl From<&Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for VecWrap<DeclareObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(DeclareObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<DeclareObjectProperty>> for Box<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<DeclareObjectProperty>>
+    for Box<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DeclareObjectProperty>) -> Self {
         Box::<horned_owl::model::DeclareObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DeclareObjectProperty<ArcStr>>> for BoxWrap<DeclareObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for BoxWrap<DeclareObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<DeclareObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DeclareObjectProperty>> for Box<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<DeclareObjectProperty>>
+    for Box<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<DeclareObjectProperty>) -> Self {
         Box::<horned_owl::model::DeclareObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DeclareObjectProperty<ArcStr>>> for BoxWrap<DeclareObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for BoxWrap<DeclareObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<DeclareObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DeclareObjectProperty>> for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<DeclareObjectProperty>>
+    for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<DeclareObjectProperty>) -> Self {
         Vec::<horned_owl::model::DeclareObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>> for VecWrap<DeclareObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for VecWrap<DeclareObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         VecWrap::<DeclareObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DeclareObjectProperty>> for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<DeclareObjectProperty>>
+    for Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<DeclareObjectProperty>) -> Self {
         Vec::<horned_owl::model::DeclareObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>> for VecWrap<DeclareObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>>
+    for VecWrap<DeclareObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>) -> Self {
         VecWrap::<DeclareObjectProperty>::from(value)
     }
@@ -8249,26 +8594,24 @@ impl FromCompatible<&Vec<horned_owl::model::DeclareObjectProperty<ArcStr>>> for 
     "\n\n",
     doc!(DeclareAnnotationProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeclareAnnotationProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DeclareAnnotationProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub AnnotationProperty,
 );
 
 #[pymethods]
 impl DeclareAnnotationProperty {
     #[new]
-    fn new(first: AnnotationProperty,) -> Self {
-        DeclareAnnotationProperty (first,)
+    fn new(first: AnnotationProperty) -> Self {
+        DeclareAnnotationProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -8281,9 +8624,10 @@ impl DeclareAnnotationProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DeclareAnnotationProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DeclareAnnotationProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -8312,43 +8656,44 @@ impl DeclareAnnotationProperty {
 
 impl From<&horned_owl::model::DeclareAnnotationProperty<ArcStr>> for DeclareAnnotationProperty {
     fn from(value: &horned_owl::model::DeclareAnnotationProperty<ArcStr>) -> Self {
-
-        DeclareAnnotationProperty (
-    IntoCompatible::<AnnotationProperty>::into_c(&value.0),
-        )
+        DeclareAnnotationProperty(IntoCompatible::<AnnotationProperty>::into_c(&value.0))
     }
 }
 
 impl From<&DeclareAnnotationProperty> for horned_owl::model::DeclareAnnotationProperty<ArcStr> {
     fn from(value: &DeclareAnnotationProperty) -> Self {
-        horned_owl::model::DeclareAnnotationProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DeclareAnnotationProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for DeclareAnnotationProperty ****************/
-impl FromCompatible<horned_owl::model::DeclareAnnotationProperty<ArcStr>> for DeclareAnnotationProperty {
+impl FromCompatible<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+    for DeclareAnnotationProperty
+{
     fn from_c(value: horned_owl::model::DeclareAnnotationProperty<ArcStr>) -> Self {
         DeclareAnnotationProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::DeclareAnnotationProperty<ArcStr>> for DeclareAnnotationProperty {
+impl FromCompatible<&horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+    for DeclareAnnotationProperty
+{
     fn from_c(value: &horned_owl::model::DeclareAnnotationProperty<ArcStr>) -> Self {
         DeclareAnnotationProperty::from(value)
     }
 }
 
-impl FromCompatible<DeclareAnnotationProperty> for horned_owl::model::DeclareAnnotationProperty<ArcStr> {
+impl FromCompatible<DeclareAnnotationProperty>
+    for horned_owl::model::DeclareAnnotationProperty<ArcStr>
+{
     fn from_c(value: DeclareAnnotationProperty) -> Self {
         horned_owl::model::DeclareAnnotationProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&DeclareAnnotationProperty> for horned_owl::model::DeclareAnnotationProperty<ArcStr> {
+impl FromCompatible<&DeclareAnnotationProperty>
+    for horned_owl::model::DeclareAnnotationProperty<ArcStr>
+{
     fn from_c(value: &DeclareAnnotationProperty) -> Self {
         horned_owl::model::DeclareAnnotationProperty::<ArcStr>::from(value)
     }
@@ -8366,43 +8711,59 @@ impl From<DeclareAnnotationProperty> for horned_owl::model::DeclareAnnotationPro
     }
 }
 
-impl From<&BoxWrap<DeclareAnnotationProperty>> for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl From<&BoxWrap<DeclareAnnotationProperty>>
+    for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<DeclareAnnotationProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for BoxWrap<DeclareAnnotationProperty> {
+impl From<&Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for BoxWrap<DeclareAnnotationProperty>
+{
     fn from(value: &Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<DeclareAnnotationProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<DeclareAnnotationProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<DeclareAnnotationProperty>> for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl From<BoxWrap<DeclareAnnotationProperty>>
+    for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from(value: BoxWrap<DeclareAnnotationProperty>) -> Self {
         Into::<Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for BoxWrap<DeclareAnnotationProperty> {
+impl From<Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for BoxWrap<DeclareAnnotationProperty>
+{
     fn from(value: Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<DeclareAnnotationProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<DeclareAnnotationProperty>> for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl From<VecWrap<DeclareAnnotationProperty>>
+    for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from(value: VecWrap<DeclareAnnotationProperty>) -> Self {
         Into::<Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for VecWrap<DeclareAnnotationProperty> {
+impl From<Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for VecWrap<DeclareAnnotationProperty>
+{
     fn from(value: Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         Into::<VecWrap<DeclareAnnotationProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<DeclareAnnotationProperty>> for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl From<&VecWrap<DeclareAnnotationProperty>>
+    for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from(value: &VecWrap<DeclareAnnotationProperty>) -> Self {
         value
             .0
@@ -8411,48 +8772,66 @@ impl From<&VecWrap<DeclareAnnotationProperty>> for Vec<horned_owl::model::Declar
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for VecWrap<DeclareAnnotationProperty> {
+impl From<&Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for VecWrap<DeclareAnnotationProperty>
+{
     fn from(value: &Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(DeclareAnnotationProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<DeclareAnnotationProperty>> for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<DeclareAnnotationProperty>>
+    for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DeclareAnnotationProperty>) -> Self {
         Box::<horned_owl::model::DeclareAnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for BoxWrap<DeclareAnnotationProperty> {
+impl FromCompatible<&Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for BoxWrap<DeclareAnnotationProperty>
+{
     fn from_c(value: &Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         BoxWrap::<DeclareAnnotationProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DeclareAnnotationProperty>> for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<DeclareAnnotationProperty>>
+    for Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<DeclareAnnotationProperty>) -> Self {
         Box::<horned_owl::model::DeclareAnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for BoxWrap<DeclareAnnotationProperty> {
+impl FromCompatible<Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for BoxWrap<DeclareAnnotationProperty>
+{
     fn from_c(value: Box<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         BoxWrap::<DeclareAnnotationProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DeclareAnnotationProperty>> for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl FromCompatible<VecWrap<DeclareAnnotationProperty>>
+    for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<DeclareAnnotationProperty>) -> Self {
         Vec::<horned_owl::model::DeclareAnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for VecWrap<DeclareAnnotationProperty> {
+impl FromCompatible<Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for VecWrap<DeclareAnnotationProperty>
+{
     fn from_c(value: Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         VecWrap::<DeclareAnnotationProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DeclareAnnotationProperty>> for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<DeclareAnnotationProperty>>
+    for Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<DeclareAnnotationProperty>) -> Self {
         Vec::<horned_owl::model::DeclareAnnotationProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> for VecWrap<DeclareAnnotationProperty> {
+impl FromCompatible<&Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>>
+    for VecWrap<DeclareAnnotationProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>) -> Self {
         VecWrap::<DeclareAnnotationProperty>::from(value)
     }
@@ -8462,26 +8841,24 @@ impl FromCompatible<&Vec<horned_owl::model::DeclareAnnotationProperty<ArcStr>>> 
     "\n\n",
     doc!(DeclareDataProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeclareDataProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DeclareDataProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub DataProperty,
 );
 
 #[pymethods]
 impl DeclareDataProperty {
     #[new]
-    fn new(first: DataProperty,) -> Self {
-        DeclareDataProperty (first,)
+    fn new(first: DataProperty) -> Self {
+        DeclareDataProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -8494,9 +8871,10 @@ impl DeclareDataProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DeclareDataProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DeclareDataProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -8525,22 +8903,15 @@ impl DeclareDataProperty {
 
 impl From<&horned_owl::model::DeclareDataProperty<ArcStr>> for DeclareDataProperty {
     fn from(value: &horned_owl::model::DeclareDataProperty<ArcStr>) -> Self {
-
-        DeclareDataProperty (
-    IntoCompatible::<DataProperty>::into_c(&value.0),
-        )
+        DeclareDataProperty(IntoCompatible::<DataProperty>::into_c(&value.0))
     }
 }
 
 impl From<&DeclareDataProperty> for horned_owl::model::DeclareDataProperty<ArcStr> {
     fn from(value: &DeclareDataProperty) -> Self {
-        horned_owl::model::DeclareDataProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DeclareDataProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DeclareDataProperty ****************/
 impl FromCompatible<horned_owl::model::DeclareDataProperty<ArcStr>> for DeclareDataProperty {
@@ -8630,42 +9001,58 @@ impl From<&Vec<horned_owl::model::DeclareDataProperty<ArcStr>>> for VecWrap<Decl
     }
 }
 
-impl FromCompatible<&BoxWrap<DeclareDataProperty>> for Box<horned_owl::model::DeclareDataProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<DeclareDataProperty>>
+    for Box<horned_owl::model::DeclareDataProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DeclareDataProperty>) -> Self {
         Box::<horned_owl::model::DeclareDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DeclareDataProperty<ArcStr>>> for BoxWrap<DeclareDataProperty> {
+impl FromCompatible<&Box<horned_owl::model::DeclareDataProperty<ArcStr>>>
+    for BoxWrap<DeclareDataProperty>
+{
     fn from_c(value: &Box<horned_owl::model::DeclareDataProperty<ArcStr>>) -> Self {
         BoxWrap::<DeclareDataProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DeclareDataProperty>> for Box<horned_owl::model::DeclareDataProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<DeclareDataProperty>>
+    for Box<horned_owl::model::DeclareDataProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<DeclareDataProperty>) -> Self {
         Box::<horned_owl::model::DeclareDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DeclareDataProperty<ArcStr>>> for BoxWrap<DeclareDataProperty> {
+impl FromCompatible<Box<horned_owl::model::DeclareDataProperty<ArcStr>>>
+    for BoxWrap<DeclareDataProperty>
+{
     fn from_c(value: Box<horned_owl::model::DeclareDataProperty<ArcStr>>) -> Self {
         BoxWrap::<DeclareDataProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DeclareDataProperty>> for Vec<horned_owl::model::DeclareDataProperty<ArcStr>> {
+impl FromCompatible<VecWrap<DeclareDataProperty>>
+    for Vec<horned_owl::model::DeclareDataProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<DeclareDataProperty>) -> Self {
         Vec::<horned_owl::model::DeclareDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DeclareDataProperty<ArcStr>>> for VecWrap<DeclareDataProperty> {
+impl FromCompatible<Vec<horned_owl::model::DeclareDataProperty<ArcStr>>>
+    for VecWrap<DeclareDataProperty>
+{
     fn from_c(value: Vec<horned_owl::model::DeclareDataProperty<ArcStr>>) -> Self {
         VecWrap::<DeclareDataProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DeclareDataProperty>> for Vec<horned_owl::model::DeclareDataProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<DeclareDataProperty>>
+    for Vec<horned_owl::model::DeclareDataProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<DeclareDataProperty>) -> Self {
         Vec::<horned_owl::model::DeclareDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DeclareDataProperty<ArcStr>>> for VecWrap<DeclareDataProperty> {
+impl FromCompatible<&Vec<horned_owl::model::DeclareDataProperty<ArcStr>>>
+    for VecWrap<DeclareDataProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::DeclareDataProperty<ArcStr>>) -> Self {
         VecWrap::<DeclareDataProperty>::from(value)
     }
@@ -8675,26 +9062,24 @@ impl FromCompatible<&Vec<horned_owl::model::DeclareDataProperty<ArcStr>>> for Ve
     "\n\n",
     doc!(DeclareNamedIndividual)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeclareNamedIndividual (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DeclareNamedIndividual(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub NamedIndividual,
 );
 
 #[pymethods]
 impl DeclareNamedIndividual {
     #[new]
-    fn new(first: NamedIndividual,) -> Self {
-        DeclareNamedIndividual (first,)
+    fn new(first: NamedIndividual) -> Self {
+        DeclareNamedIndividual(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -8707,9 +9092,10 @@ impl DeclareNamedIndividual {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DeclareNamedIndividual<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DeclareNamedIndividual<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -8738,22 +9124,15 @@ impl DeclareNamedIndividual {
 
 impl From<&horned_owl::model::DeclareNamedIndividual<ArcStr>> for DeclareNamedIndividual {
     fn from(value: &horned_owl::model::DeclareNamedIndividual<ArcStr>) -> Self {
-
-        DeclareNamedIndividual (
-    IntoCompatible::<NamedIndividual>::into_c(&value.0),
-        )
+        DeclareNamedIndividual(IntoCompatible::<NamedIndividual>::into_c(&value.0))
     }
 }
 
 impl From<&DeclareNamedIndividual> for horned_owl::model::DeclareNamedIndividual<ArcStr> {
     fn from(value: &DeclareNamedIndividual) -> Self {
-        horned_owl::model::DeclareNamedIndividual::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DeclareNamedIndividual::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DeclareNamedIndividual ****************/
 impl FromCompatible<horned_owl::model::DeclareNamedIndividual<ArcStr>> for DeclareNamedIndividual {
@@ -8792,43 +9171,59 @@ impl From<DeclareNamedIndividual> for horned_owl::model::DeclareNamedIndividual<
     }
 }
 
-impl From<&BoxWrap<DeclareNamedIndividual>> for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl From<&BoxWrap<DeclareNamedIndividual>>
+    for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from(value: &BoxWrap<DeclareNamedIndividual>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for BoxWrap<DeclareNamedIndividual> {
+impl From<&Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for BoxWrap<DeclareNamedIndividual>
+{
     fn from(value: &Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<DeclareNamedIndividual>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<DeclareNamedIndividual>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<DeclareNamedIndividual>> for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl From<BoxWrap<DeclareNamedIndividual>>
+    for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from(value: BoxWrap<DeclareNamedIndividual>) -> Self {
         Into::<Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for BoxWrap<DeclareNamedIndividual> {
+impl From<Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for BoxWrap<DeclareNamedIndividual>
+{
     fn from(value: Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         Into::<BoxWrap<DeclareNamedIndividual>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<DeclareNamedIndividual>> for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl From<VecWrap<DeclareNamedIndividual>>
+    for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from(value: VecWrap<DeclareNamedIndividual>) -> Self {
         Into::<Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for VecWrap<DeclareNamedIndividual> {
+impl From<Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for VecWrap<DeclareNamedIndividual>
+{
     fn from(value: Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         Into::<VecWrap<DeclareNamedIndividual>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<DeclareNamedIndividual>> for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl From<&VecWrap<DeclareNamedIndividual>>
+    for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from(value: &VecWrap<DeclareNamedIndividual>) -> Self {
         value
             .0
@@ -8837,48 +9232,66 @@ impl From<&VecWrap<DeclareNamedIndividual>> for Vec<horned_owl::model::DeclareNa
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for VecWrap<DeclareNamedIndividual> {
+impl From<&Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for VecWrap<DeclareNamedIndividual>
+{
     fn from(value: &Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         VecWrap(value.iter().map(DeclareNamedIndividual::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<DeclareNamedIndividual>> for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl FromCompatible<&BoxWrap<DeclareNamedIndividual>>
+    for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DeclareNamedIndividual>) -> Self {
         Box::<horned_owl::model::DeclareNamedIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for BoxWrap<DeclareNamedIndividual> {
+impl FromCompatible<&Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for BoxWrap<DeclareNamedIndividual>
+{
     fn from_c(value: &Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         BoxWrap::<DeclareNamedIndividual>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DeclareNamedIndividual>> for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl FromCompatible<BoxWrap<DeclareNamedIndividual>>
+    for Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from_c(value: BoxWrap<DeclareNamedIndividual>) -> Self {
         Box::<horned_owl::model::DeclareNamedIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for BoxWrap<DeclareNamedIndividual> {
+impl FromCompatible<Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for BoxWrap<DeclareNamedIndividual>
+{
     fn from_c(value: Box<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         BoxWrap::<DeclareNamedIndividual>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DeclareNamedIndividual>> for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl FromCompatible<VecWrap<DeclareNamedIndividual>>
+    for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from_c(value: VecWrap<DeclareNamedIndividual>) -> Self {
         Vec::<horned_owl::model::DeclareNamedIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for VecWrap<DeclareNamedIndividual> {
+impl FromCompatible<Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for VecWrap<DeclareNamedIndividual>
+{
     fn from_c(value: Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         VecWrap::<DeclareNamedIndividual>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DeclareNamedIndividual>> for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>> {
+impl FromCompatible<&VecWrap<DeclareNamedIndividual>>
+    for Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>
+{
     fn from_c(value: &VecWrap<DeclareNamedIndividual>) -> Self {
         Vec::<horned_owl::model::DeclareNamedIndividual<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for VecWrap<DeclareNamedIndividual> {
+impl FromCompatible<&Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>>
+    for VecWrap<DeclareNamedIndividual>
+{
     fn from_c(value: &Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>) -> Self {
         VecWrap::<DeclareNamedIndividual>::from(value)
     }
@@ -8888,26 +9301,24 @@ impl FromCompatible<&Vec<horned_owl::model::DeclareNamedIndividual<ArcStr>>> for
     "\n\n",
     doc!(DeclareDatatype)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DeclareDatatype (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DeclareDatatype(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub Datatype,
 );
 
 #[pymethods]
 impl DeclareDatatype {
     #[new]
-    fn new(first: Datatype,) -> Self {
-        DeclareDatatype (first,)
+    fn new(first: Datatype) -> Self {
+        DeclareDatatype(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -8920,9 +9331,10 @@ impl DeclareDatatype {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DeclareDatatype<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DeclareDatatype<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -8951,22 +9363,15 @@ impl DeclareDatatype {
 
 impl From<&horned_owl::model::DeclareDatatype<ArcStr>> for DeclareDatatype {
     fn from(value: &horned_owl::model::DeclareDatatype<ArcStr>) -> Self {
-
-        DeclareDatatype (
-    IntoCompatible::<Datatype>::into_c(&value.0),
-        )
+        DeclareDatatype(IntoCompatible::<Datatype>::into_c(&value.0))
     }
 }
 
 impl From<&DeclareDatatype> for horned_owl::model::DeclareDatatype<ArcStr> {
     fn from(value: &DeclareDatatype) -> Self {
-        horned_owl::model::DeclareDatatype::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DeclareDatatype::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DeclareDatatype ****************/
 impl FromCompatible<horned_owl::model::DeclareDatatype<ArcStr>> for DeclareDatatype {
@@ -9100,41 +9505,38 @@ impl FromCompatible<&Vec<horned_owl::model::DeclareDatatype<ArcStr>>> for VecWra
     "\n\n",
     doc!(SubClassOf)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubClassOf {
-        #[doc="sub: ClassExpression"]
-        #[pyo3(get,set)]
-        pub sub: ClassExpression,
-    
-        #[doc="sup: ClassExpression"]
-        #[pyo3(get,set)]
-        pub sup: ClassExpression,
-    }
+    #[doc = "sub: ClassExpression"]
+    #[pyo3(get, set)]
+    pub sub: ClassExpression,
+
+    #[doc = "sup: ClassExpression"]
+    #[pyo3(get, set)]
+    pub sup: ClassExpression,
+}
 
 #[pymethods]
 impl SubClassOf {
     #[new]
-    fn new(sub: ClassExpression,sup: ClassExpression,) -> Self {
-        SubClassOf {
-                sub,
-                sup,
-        }
+    fn new(sub: ClassExpression, sup: ClassExpression) -> Self {
+        SubClassOf { sub, sup }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "sub".to_string(),
-            "sup".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("sub".to_string(), "sup".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "sub" => self.sub.clone().into_pyobject(py).map(Bound::into_any),
             "sup" => self.sup.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -9143,12 +9545,15 @@ impl SubClassOf {
             "sub" => {
                 self.sub = value.extract()?;
                 Ok(())
-            },
+            }
             "sup" => {
                 self.sup = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -9162,9 +9567,10 @@ impl SubClassOf {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::SubClassOf<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::SubClassOf<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -9200,7 +9606,6 @@ impl From<&horned_owl::model::SubClassOf<ArcStr>> for SubClassOf {
     }
 }
 
-
 impl From<&SubClassOf> for horned_owl::model::SubClassOf<ArcStr> {
     fn from(value: &SubClassOf) -> Self {
         horned_owl::model::SubClassOf::<ArcStr> {
@@ -9209,8 +9614,6 @@ impl From<&SubClassOf> for horned_owl::model::SubClassOf<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for SubClassOf ****************/
 impl FromCompatible<horned_owl::model::SubClassOf<ArcStr>> for SubClassOf {
@@ -9345,26 +9748,24 @@ impl FromCompatible<&Vec<horned_owl::model::SubClassOf<ArcStr>>> for VecWrap<Sub
     "\n\n",
     doc!(EquivalentClasses)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EquivalentClasses (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct EquivalentClasses(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<ClassExpression>,
 );
 
 #[pymethods]
 impl EquivalentClasses {
     #[new]
-    fn new(first: VecWrap<ClassExpression>,) -> Self {
-        EquivalentClasses (first,)
+    fn new(first: VecWrap<ClassExpression>) -> Self {
+        EquivalentClasses(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -9377,9 +9778,10 @@ impl EquivalentClasses {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::EquivalentClasses<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::EquivalentClasses<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -9408,22 +9810,15 @@ impl EquivalentClasses {
 
 impl From<&horned_owl::model::EquivalentClasses<ArcStr>> for EquivalentClasses {
     fn from(value: &horned_owl::model::EquivalentClasses<ArcStr>) -> Self {
-
-        EquivalentClasses (
-    IntoCompatible::<VecWrap<ClassExpression>>::into_c(&value.0),
-        )
+        EquivalentClasses(IntoCompatible::<VecWrap<ClassExpression>>::into_c(&value.0))
     }
 }
 
 impl From<&EquivalentClasses> for horned_owl::model::EquivalentClasses<ArcStr> {
     fn from(value: &EquivalentClasses) -> Self {
-        horned_owl::model::EquivalentClasses::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::EquivalentClasses::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for EquivalentClasses ****************/
 impl FromCompatible<horned_owl::model::EquivalentClasses<ArcStr>> for EquivalentClasses {
@@ -9513,42 +9908,58 @@ impl From<&Vec<horned_owl::model::EquivalentClasses<ArcStr>>> for VecWrap<Equiva
     }
 }
 
-impl FromCompatible<&BoxWrap<EquivalentClasses>> for Box<horned_owl::model::EquivalentClasses<ArcStr>> {
+impl FromCompatible<&BoxWrap<EquivalentClasses>>
+    for Box<horned_owl::model::EquivalentClasses<ArcStr>>
+{
     fn from_c(value: &BoxWrap<EquivalentClasses>) -> Self {
         Box::<horned_owl::model::EquivalentClasses<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::EquivalentClasses<ArcStr>>> for BoxWrap<EquivalentClasses> {
+impl FromCompatible<&Box<horned_owl::model::EquivalentClasses<ArcStr>>>
+    for BoxWrap<EquivalentClasses>
+{
     fn from_c(value: &Box<horned_owl::model::EquivalentClasses<ArcStr>>) -> Self {
         BoxWrap::<EquivalentClasses>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<EquivalentClasses>> for Box<horned_owl::model::EquivalentClasses<ArcStr>> {
+impl FromCompatible<BoxWrap<EquivalentClasses>>
+    for Box<horned_owl::model::EquivalentClasses<ArcStr>>
+{
     fn from_c(value: BoxWrap<EquivalentClasses>) -> Self {
         Box::<horned_owl::model::EquivalentClasses<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::EquivalentClasses<ArcStr>>> for BoxWrap<EquivalentClasses> {
+impl FromCompatible<Box<horned_owl::model::EquivalentClasses<ArcStr>>>
+    for BoxWrap<EquivalentClasses>
+{
     fn from_c(value: Box<horned_owl::model::EquivalentClasses<ArcStr>>) -> Self {
         BoxWrap::<EquivalentClasses>::from(value)
     }
 }
-impl FromCompatible<VecWrap<EquivalentClasses>> for Vec<horned_owl::model::EquivalentClasses<ArcStr>> {
+impl FromCompatible<VecWrap<EquivalentClasses>>
+    for Vec<horned_owl::model::EquivalentClasses<ArcStr>>
+{
     fn from_c(value: VecWrap<EquivalentClasses>) -> Self {
         Vec::<horned_owl::model::EquivalentClasses<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::EquivalentClasses<ArcStr>>> for VecWrap<EquivalentClasses> {
+impl FromCompatible<Vec<horned_owl::model::EquivalentClasses<ArcStr>>>
+    for VecWrap<EquivalentClasses>
+{
     fn from_c(value: Vec<horned_owl::model::EquivalentClasses<ArcStr>>) -> Self {
         VecWrap::<EquivalentClasses>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<EquivalentClasses>> for Vec<horned_owl::model::EquivalentClasses<ArcStr>> {
+impl FromCompatible<&VecWrap<EquivalentClasses>>
+    for Vec<horned_owl::model::EquivalentClasses<ArcStr>>
+{
     fn from_c(value: &VecWrap<EquivalentClasses>) -> Self {
         Vec::<horned_owl::model::EquivalentClasses<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::EquivalentClasses<ArcStr>>> for VecWrap<EquivalentClasses> {
+impl FromCompatible<&Vec<horned_owl::model::EquivalentClasses<ArcStr>>>
+    for VecWrap<EquivalentClasses>
+{
     fn from_c(value: &Vec<horned_owl::model::EquivalentClasses<ArcStr>>) -> Self {
         VecWrap::<EquivalentClasses>::from(value)
     }
@@ -9558,26 +9969,24 @@ impl FromCompatible<&Vec<horned_owl::model::EquivalentClasses<ArcStr>>> for VecW
     "\n\n",
     doc!(DisjointClasses)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DisjointClasses (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DisjointClasses(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<ClassExpression>,
 );
 
 #[pymethods]
 impl DisjointClasses {
     #[new]
-    fn new(first: VecWrap<ClassExpression>,) -> Self {
-        DisjointClasses (first,)
+    fn new(first: VecWrap<ClassExpression>) -> Self {
+        DisjointClasses(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -9590,9 +9999,10 @@ impl DisjointClasses {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DisjointClasses<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DisjointClasses<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -9621,22 +10031,15 @@ impl DisjointClasses {
 
 impl From<&horned_owl::model::DisjointClasses<ArcStr>> for DisjointClasses {
     fn from(value: &horned_owl::model::DisjointClasses<ArcStr>) -> Self {
-
-        DisjointClasses (
-    IntoCompatible::<VecWrap<ClassExpression>>::into_c(&value.0),
-        )
+        DisjointClasses(IntoCompatible::<VecWrap<ClassExpression>>::into_c(&value.0))
     }
 }
 
 impl From<&DisjointClasses> for horned_owl::model::DisjointClasses<ArcStr> {
     fn from(value: &DisjointClasses) -> Self {
-        horned_owl::model::DisjointClasses::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DisjointClasses::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DisjointClasses ****************/
 impl FromCompatible<horned_owl::model::DisjointClasses<ArcStr>> for DisjointClasses {
@@ -9771,30 +10174,27 @@ impl FromCompatible<&Vec<horned_owl::model::DisjointClasses<ArcStr>>> for VecWra
     "\n\n",
     doc!(DisjointUnion)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DisjointUnion (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DisjointUnion(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub Class,
-    #[doc="second: "]
-    #[pyo3(get,set,name="second")]
+    #[doc = "second: "]
+    #[pyo3(get, set, name = "second")]
     pub VecWrap<ClassExpression>,
 );
 
 #[pymethods]
 impl DisjointUnion {
     #[new]
-    fn new(first: Class,second: VecWrap<ClassExpression>,) -> Self {
-        DisjointUnion (first,second,)
+    fn new(first: Class, second: VecWrap<ClassExpression>) -> Self {
+        DisjointUnion(first, second)
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "first".to_string(),
-            "second".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("first".to_string(), "second".to_string()))
     }
 
     fn __hash__(&self) -> u64 {
@@ -9807,9 +10207,10 @@ impl DisjointUnion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DisjointUnion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DisjointUnion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -9838,24 +10239,21 @@ impl DisjointUnion {
 
 impl From<&horned_owl::model::DisjointUnion<ArcStr>> for DisjointUnion {
     fn from(value: &horned_owl::model::DisjointUnion<ArcStr>) -> Self {
-
-        DisjointUnion (
-    IntoCompatible::<Class>::into_c(&value.0),
-    IntoCompatible::<VecWrap<ClassExpression>>::into_c(&value.1),
+        DisjointUnion(
+            IntoCompatible::<Class>::into_c(&value.0),
+            IntoCompatible::<VecWrap<ClassExpression>>::into_c(&value.1),
         )
     }
 }
 
 impl From<&DisjointUnion> for horned_owl::model::DisjointUnion<ArcStr> {
     fn from(value: &DisjointUnion) -> Self {
-        horned_owl::model::DisjointUnion::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-    IntoCompatible::into_c(&value.1),
+        horned_owl::model::DisjointUnion::<ArcStr>(
+            IntoCompatible::into_c(&value.0),
+            IntoCompatible::into_c(&value.1),
         )
     }
 }
-
-
 
 /**************** Base implementations for DisjointUnion ****************/
 impl FromCompatible<horned_owl::model::DisjointUnion<ArcStr>> for DisjointUnion {
@@ -9987,13 +10385,11 @@ impl FromCompatible<&Vec<horned_owl::model::DisjointUnion<ArcStr>>> for VecWrap<
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum SubObjectPropertyExpression {
-    
-        #[pyo3(transparent)]
-        ObjectPropertyChain (VecWrap<ObjectPropertyExpression>),
-    
-        #[pyo3(transparent)]
-        ObjectPropertyExpression (ObjectPropertyExpression),
-    
+    #[pyo3(transparent)]
+    ObjectPropertyChain(VecWrap<ObjectPropertyExpression>),
+
+    #[pyo3(transparent)]
+    ObjectPropertyExpression(ObjectPropertyExpression),
 }
 
 impl<'py> IntoPyObject<'py> for SubObjectPropertyExpression {
@@ -10003,11 +10399,13 @@ impl<'py> IntoPyObject<'py> for SubObjectPropertyExpression {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
-            SubObjectPropertyExpression::ObjectPropertyChain(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            SubObjectPropertyExpression::ObjectPropertyExpression(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+            SubObjectPropertyExpression::ObjectPropertyChain(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            SubObjectPropertyExpression::ObjectPropertyExpression(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
         }
     }
 }
@@ -10015,28 +10413,32 @@ impl<'py> IntoPyObject<'py> for SubObjectPropertyExpression {
 impl From<&SubObjectPropertyExpression> for horned_owl::model::SubObjectPropertyExpression<ArcStr> {
     fn from(value: &SubObjectPropertyExpression) -> Self {
         match value {
-        
-            SubObjectPropertyExpression::ObjectPropertyChain(inner) => horned_owl::model::SubObjectPropertyExpression::ObjectPropertyChain(inner.into()),
-        
-            SubObjectPropertyExpression::ObjectPropertyExpression(inner) => horned_owl::model::SubObjectPropertyExpression::ObjectPropertyExpression(inner.into()),
-        
+            SubObjectPropertyExpression::ObjectPropertyChain(inner) => {
+                horned_owl::model::SubObjectPropertyExpression::ObjectPropertyChain(inner.into())
+            }
+
+            SubObjectPropertyExpression::ObjectPropertyExpression(inner) => {
+                horned_owl::model::SubObjectPropertyExpression::ObjectPropertyExpression(
+                    inner.into(),
+                )
+            }
         }
     }
 }
 
 impl From<&horned_owl::model::SubObjectPropertyExpression<ArcStr>> for SubObjectPropertyExpression {
-
     fn from(value: &horned_owl::model::SubObjectPropertyExpression<ArcStr>) -> Self {
         match value {
-        
-            horned_owl::model::SubObjectPropertyExpression::ObjectPropertyChain(inner) => SubObjectPropertyExpression::ObjectPropertyChain(inner.into()),
-        
-            horned_owl::model::SubObjectPropertyExpression::ObjectPropertyExpression(inner) => SubObjectPropertyExpression::ObjectPropertyExpression(inner.into()),
-        
+            horned_owl::model::SubObjectPropertyExpression::ObjectPropertyChain(inner) => {
+                SubObjectPropertyExpression::ObjectPropertyChain(inner.into())
+            }
+
+            horned_owl::model::SubObjectPropertyExpression::ObjectPropertyExpression(inner) => {
+                SubObjectPropertyExpression::ObjectPropertyExpression(inner.into())
+            }
         }
     }
 }
-
 
 impl SubObjectPropertyExpression {
     pub fn py_def() -> String {
@@ -10044,28 +10446,34 @@ impl SubObjectPropertyExpression {
     }
 }
 
-
-
 /**************** Base implementations for SubObjectPropertyExpression ****************/
-impl FromCompatible<horned_owl::model::SubObjectPropertyExpression<ArcStr>> for SubObjectPropertyExpression {
+impl FromCompatible<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+    for SubObjectPropertyExpression
+{
     fn from_c(value: horned_owl::model::SubObjectPropertyExpression<ArcStr>) -> Self {
         SubObjectPropertyExpression::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::SubObjectPropertyExpression<ArcStr>> for SubObjectPropertyExpression {
+impl FromCompatible<&horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+    for SubObjectPropertyExpression
+{
     fn from_c(value: &horned_owl::model::SubObjectPropertyExpression<ArcStr>) -> Self {
         SubObjectPropertyExpression::from(value)
     }
 }
 
-impl FromCompatible<SubObjectPropertyExpression> for horned_owl::model::SubObjectPropertyExpression<ArcStr> {
+impl FromCompatible<SubObjectPropertyExpression>
+    for horned_owl::model::SubObjectPropertyExpression<ArcStr>
+{
     fn from_c(value: SubObjectPropertyExpression) -> Self {
         horned_owl::model::SubObjectPropertyExpression::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&SubObjectPropertyExpression> for horned_owl::model::SubObjectPropertyExpression<ArcStr> {
+impl FromCompatible<&SubObjectPropertyExpression>
+    for horned_owl::model::SubObjectPropertyExpression<ArcStr>
+{
     fn from_c(value: &SubObjectPropertyExpression) -> Self {
         horned_owl::model::SubObjectPropertyExpression::<ArcStr>::from(value)
     }
@@ -10083,43 +10491,59 @@ impl From<SubObjectPropertyExpression> for horned_owl::model::SubObjectPropertyE
     }
 }
 
-impl From<&BoxWrap<SubObjectPropertyExpression>> for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl From<&BoxWrap<SubObjectPropertyExpression>>
+    for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from(value: &BoxWrap<SubObjectPropertyExpression>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for BoxWrap<SubObjectPropertyExpression> {
+impl From<&Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<SubObjectPropertyExpression>
+{
     fn from(value: &Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<SubObjectPropertyExpression>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<SubObjectPropertyExpression>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<SubObjectPropertyExpression>> for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl From<BoxWrap<SubObjectPropertyExpression>>
+    for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from(value: BoxWrap<SubObjectPropertyExpression>) -> Self {
         Into::<Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for BoxWrap<SubObjectPropertyExpression> {
+impl From<Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<SubObjectPropertyExpression>
+{
     fn from(value: Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
         Into::<BoxWrap<SubObjectPropertyExpression>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<SubObjectPropertyExpression>> for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl From<VecWrap<SubObjectPropertyExpression>>
+    for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from(value: VecWrap<SubObjectPropertyExpression>) -> Self {
         Into::<Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for VecWrap<SubObjectPropertyExpression> {
+impl From<Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for VecWrap<SubObjectPropertyExpression>
+{
     fn from(value: Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
         Into::<VecWrap<SubObjectPropertyExpression>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<SubObjectPropertyExpression>> for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl From<&VecWrap<SubObjectPropertyExpression>>
+    for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from(value: &VecWrap<SubObjectPropertyExpression>) -> Self {
         value
             .0
@@ -10128,48 +10552,71 @@ impl From<&VecWrap<SubObjectPropertyExpression>> for Vec<horned_owl::model::SubO
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for VecWrap<SubObjectPropertyExpression> {
+impl From<&Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for VecWrap<SubObjectPropertyExpression>
+{
     fn from(value: &Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
-        VecWrap(value.iter().map(SubObjectPropertyExpression::from).collect())
+        VecWrap(
+            value
+                .iter()
+                .map(SubObjectPropertyExpression::from)
+                .collect(),
+        )
     }
 }
 
-impl FromCompatible<&BoxWrap<SubObjectPropertyExpression>> for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<&BoxWrap<SubObjectPropertyExpression>>
+    for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: &BoxWrap<SubObjectPropertyExpression>) -> Self {
         Box::<horned_owl::model::SubObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for BoxWrap<SubObjectPropertyExpression> {
+impl FromCompatible<&Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<SubObjectPropertyExpression>
+{
     fn from_c(value: &Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
         BoxWrap::<SubObjectPropertyExpression>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<SubObjectPropertyExpression>> for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<BoxWrap<SubObjectPropertyExpression>>
+    for Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: BoxWrap<SubObjectPropertyExpression>) -> Self {
         Box::<horned_owl::model::SubObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for BoxWrap<SubObjectPropertyExpression> {
+impl FromCompatible<Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for BoxWrap<SubObjectPropertyExpression>
+{
     fn from_c(value: Box<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
         BoxWrap::<SubObjectPropertyExpression>::from(value)
     }
 }
-impl FromCompatible<VecWrap<SubObjectPropertyExpression>> for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<VecWrap<SubObjectPropertyExpression>>
+    for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: VecWrap<SubObjectPropertyExpression>) -> Self {
         Vec::<horned_owl::model::SubObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for VecWrap<SubObjectPropertyExpression> {
+impl FromCompatible<Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for VecWrap<SubObjectPropertyExpression>
+{
     fn from_c(value: Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
         VecWrap::<SubObjectPropertyExpression>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<SubObjectPropertyExpression>> for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>> {
+impl FromCompatible<&VecWrap<SubObjectPropertyExpression>>
+    for Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
+{
     fn from_c(value: &VecWrap<SubObjectPropertyExpression>) -> Self {
         Vec::<horned_owl::model::SubObjectPropertyExpression<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>> for VecWrap<SubObjectPropertyExpression> {
+impl FromCompatible<&Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>>
+    for VecWrap<SubObjectPropertyExpression>
+{
     fn from_c(value: &Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>) -> Self {
         VecWrap::<SubObjectPropertyExpression>::from(value)
     }
@@ -10178,41 +10625,38 @@ impl FromCompatible<&Vec<horned_owl::model::SubObjectPropertyExpression<ArcStr>>
     "\n\n",
     doc!(SubObjectPropertyOf)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubObjectPropertyOf {
-        #[doc="sub: SubObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub sub: SubObjectPropertyExpression,
-    
-        #[doc="sup: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub sup: ObjectPropertyExpression,
-    }
+    #[doc = "sub: SubObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub sub: SubObjectPropertyExpression,
+
+    #[doc = "sup: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub sup: ObjectPropertyExpression,
+}
 
 #[pymethods]
 impl SubObjectPropertyOf {
     #[new]
-    fn new(sub: SubObjectPropertyExpression,sup: ObjectPropertyExpression,) -> Self {
-        SubObjectPropertyOf {
-                sub,
-                sup,
-        }
+    fn new(sub: SubObjectPropertyExpression, sup: ObjectPropertyExpression) -> Self {
+        SubObjectPropertyOf { sub, sup }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "sub".to_string(),
-            "sup".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("sub".to_string(), "sup".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "sub" => self.sub.clone().into_pyobject(py).map(Bound::into_any),
             "sup" => self.sup.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -10221,12 +10665,15 @@ impl SubObjectPropertyOf {
             "sub" => {
                 self.sub = value.extract()?;
                 Ok(())
-            },
+            }
             "sup" => {
                 self.sup = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -10240,9 +10687,10 @@ impl SubObjectPropertyOf {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::SubObjectPropertyOf<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::SubObjectPropertyOf<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -10278,7 +10726,6 @@ impl From<&horned_owl::model::SubObjectPropertyOf<ArcStr>> for SubObjectProperty
     }
 }
 
-
 impl From<&SubObjectPropertyOf> for horned_owl::model::SubObjectPropertyOf<ArcStr> {
     fn from(value: &SubObjectPropertyOf) -> Self {
         horned_owl::model::SubObjectPropertyOf::<ArcStr> {
@@ -10287,8 +10734,6 @@ impl From<&SubObjectPropertyOf> for horned_owl::model::SubObjectPropertyOf<ArcSt
         }
     }
 }
-
-
 
 /**************** Base implementations for SubObjectPropertyOf ****************/
 impl FromCompatible<horned_owl::model::SubObjectPropertyOf<ArcStr>> for SubObjectPropertyOf {
@@ -10378,42 +10823,58 @@ impl From<&Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>> for VecWrap<SubO
     }
 }
 
-impl FromCompatible<&BoxWrap<SubObjectPropertyOf>> for Box<horned_owl::model::SubObjectPropertyOf<ArcStr>> {
+impl FromCompatible<&BoxWrap<SubObjectPropertyOf>>
+    for Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>
+{
     fn from_c(value: &BoxWrap<SubObjectPropertyOf>) -> Self {
         Box::<horned_owl::model::SubObjectPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>> for BoxWrap<SubObjectPropertyOf> {
+impl FromCompatible<&Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>>
+    for BoxWrap<SubObjectPropertyOf>
+{
     fn from_c(value: &Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>) -> Self {
         BoxWrap::<SubObjectPropertyOf>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<SubObjectPropertyOf>> for Box<horned_owl::model::SubObjectPropertyOf<ArcStr>> {
+impl FromCompatible<BoxWrap<SubObjectPropertyOf>>
+    for Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>
+{
     fn from_c(value: BoxWrap<SubObjectPropertyOf>) -> Self {
         Box::<horned_owl::model::SubObjectPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>> for BoxWrap<SubObjectPropertyOf> {
+impl FromCompatible<Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>>
+    for BoxWrap<SubObjectPropertyOf>
+{
     fn from_c(value: Box<horned_owl::model::SubObjectPropertyOf<ArcStr>>) -> Self {
         BoxWrap::<SubObjectPropertyOf>::from(value)
     }
 }
-impl FromCompatible<VecWrap<SubObjectPropertyOf>> for Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>> {
+impl FromCompatible<VecWrap<SubObjectPropertyOf>>
+    for Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>
+{
     fn from_c(value: VecWrap<SubObjectPropertyOf>) -> Self {
         Vec::<horned_owl::model::SubObjectPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>> for VecWrap<SubObjectPropertyOf> {
+impl FromCompatible<Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>>
+    for VecWrap<SubObjectPropertyOf>
+{
     fn from_c(value: Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>) -> Self {
         VecWrap::<SubObjectPropertyOf>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<SubObjectPropertyOf>> for Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>> {
+impl FromCompatible<&VecWrap<SubObjectPropertyOf>>
+    for Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>
+{
     fn from_c(value: &VecWrap<SubObjectPropertyOf>) -> Self {
         Vec::<horned_owl::model::SubObjectPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>> for VecWrap<SubObjectPropertyOf> {
+impl FromCompatible<&Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>>
+    for VecWrap<SubObjectPropertyOf>
+{
     fn from_c(value: &Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>) -> Self {
         VecWrap::<SubObjectPropertyOf>::from(value)
     }
@@ -10423,26 +10884,24 @@ impl FromCompatible<&Vec<horned_owl::model::SubObjectPropertyOf<ArcStr>>> for Ve
     "\n\n",
     doc!(EquivalentObjectProperties)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EquivalentObjectProperties (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct EquivalentObjectProperties(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<ObjectPropertyExpression>,
 );
 
 #[pymethods]
 impl EquivalentObjectProperties {
     #[new]
-    fn new(first: VecWrap<ObjectPropertyExpression>,) -> Self {
-        EquivalentObjectProperties (first,)
+    fn new(first: VecWrap<ObjectPropertyExpression>) -> Self {
+        EquivalentObjectProperties(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -10455,9 +10914,10 @@ impl EquivalentObjectProperties {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::EquivalentObjectProperties<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::EquivalentObjectProperties<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -10486,43 +10946,46 @@ impl EquivalentObjectProperties {
 
 impl From<&horned_owl::model::EquivalentObjectProperties<ArcStr>> for EquivalentObjectProperties {
     fn from(value: &horned_owl::model::EquivalentObjectProperties<ArcStr>) -> Self {
-
-        EquivalentObjectProperties (
-    IntoCompatible::<VecWrap<ObjectPropertyExpression>>::into_c(&value.0),
-        )
+        EquivalentObjectProperties(IntoCompatible::<VecWrap<ObjectPropertyExpression>>::into_c(
+            &value.0,
+        ))
     }
 }
 
 impl From<&EquivalentObjectProperties> for horned_owl::model::EquivalentObjectProperties<ArcStr> {
     fn from(value: &EquivalentObjectProperties) -> Self {
-        horned_owl::model::EquivalentObjectProperties::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::EquivalentObjectProperties::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for EquivalentObjectProperties ****************/
-impl FromCompatible<horned_owl::model::EquivalentObjectProperties<ArcStr>> for EquivalentObjectProperties {
+impl FromCompatible<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+    for EquivalentObjectProperties
+{
     fn from_c(value: horned_owl::model::EquivalentObjectProperties<ArcStr>) -> Self {
         EquivalentObjectProperties::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::EquivalentObjectProperties<ArcStr>> for EquivalentObjectProperties {
+impl FromCompatible<&horned_owl::model::EquivalentObjectProperties<ArcStr>>
+    for EquivalentObjectProperties
+{
     fn from_c(value: &horned_owl::model::EquivalentObjectProperties<ArcStr>) -> Self {
         EquivalentObjectProperties::from(value)
     }
 }
 
-impl FromCompatible<EquivalentObjectProperties> for horned_owl::model::EquivalentObjectProperties<ArcStr> {
+impl FromCompatible<EquivalentObjectProperties>
+    for horned_owl::model::EquivalentObjectProperties<ArcStr>
+{
     fn from_c(value: EquivalentObjectProperties) -> Self {
         horned_owl::model::EquivalentObjectProperties::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&EquivalentObjectProperties> for horned_owl::model::EquivalentObjectProperties<ArcStr> {
+impl FromCompatible<&EquivalentObjectProperties>
+    for horned_owl::model::EquivalentObjectProperties<ArcStr>
+{
     fn from_c(value: &EquivalentObjectProperties) -> Self {
         horned_owl::model::EquivalentObjectProperties::<ArcStr>::from(value)
     }
@@ -10540,43 +11003,59 @@ impl From<EquivalentObjectProperties> for horned_owl::model::EquivalentObjectPro
     }
 }
 
-impl From<&BoxWrap<EquivalentObjectProperties>> for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl From<&BoxWrap<EquivalentObjectProperties>>
+    for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from(value: &BoxWrap<EquivalentObjectProperties>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for BoxWrap<EquivalentObjectProperties> {
+impl From<&Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for BoxWrap<EquivalentObjectProperties>
+{
     fn from(value: &Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<EquivalentObjectProperties>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<EquivalentObjectProperties>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<EquivalentObjectProperties>> for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl From<BoxWrap<EquivalentObjectProperties>>
+    for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from(value: BoxWrap<EquivalentObjectProperties>) -> Self {
         Into::<Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for BoxWrap<EquivalentObjectProperties> {
+impl From<Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for BoxWrap<EquivalentObjectProperties>
+{
     fn from(value: Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         Into::<BoxWrap<EquivalentObjectProperties>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<EquivalentObjectProperties>> for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl From<VecWrap<EquivalentObjectProperties>>
+    for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from(value: VecWrap<EquivalentObjectProperties>) -> Self {
         Into::<Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for VecWrap<EquivalentObjectProperties> {
+impl From<Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for VecWrap<EquivalentObjectProperties>
+{
     fn from(value: Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         Into::<VecWrap<EquivalentObjectProperties>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<EquivalentObjectProperties>> for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl From<&VecWrap<EquivalentObjectProperties>>
+    for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from(value: &VecWrap<EquivalentObjectProperties>) -> Self {
         value
             .0
@@ -10585,48 +11064,66 @@ impl From<&VecWrap<EquivalentObjectProperties>> for Vec<horned_owl::model::Equiv
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for VecWrap<EquivalentObjectProperties> {
+impl From<&Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for VecWrap<EquivalentObjectProperties>
+{
     fn from(value: &Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         VecWrap(value.iter().map(EquivalentObjectProperties::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<EquivalentObjectProperties>> for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl FromCompatible<&BoxWrap<EquivalentObjectProperties>>
+    for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from_c(value: &BoxWrap<EquivalentObjectProperties>) -> Self {
         Box::<horned_owl::model::EquivalentObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for BoxWrap<EquivalentObjectProperties> {
+impl FromCompatible<&Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for BoxWrap<EquivalentObjectProperties>
+{
     fn from_c(value: &Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         BoxWrap::<EquivalentObjectProperties>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<EquivalentObjectProperties>> for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl FromCompatible<BoxWrap<EquivalentObjectProperties>>
+    for Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from_c(value: BoxWrap<EquivalentObjectProperties>) -> Self {
         Box::<horned_owl::model::EquivalentObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for BoxWrap<EquivalentObjectProperties> {
+impl FromCompatible<Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for BoxWrap<EquivalentObjectProperties>
+{
     fn from_c(value: Box<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         BoxWrap::<EquivalentObjectProperties>::from(value)
     }
 }
-impl FromCompatible<VecWrap<EquivalentObjectProperties>> for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl FromCompatible<VecWrap<EquivalentObjectProperties>>
+    for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from_c(value: VecWrap<EquivalentObjectProperties>) -> Self {
         Vec::<horned_owl::model::EquivalentObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for VecWrap<EquivalentObjectProperties> {
+impl FromCompatible<Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for VecWrap<EquivalentObjectProperties>
+{
     fn from_c(value: Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         VecWrap::<EquivalentObjectProperties>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<EquivalentObjectProperties>> for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>> {
+impl FromCompatible<&VecWrap<EquivalentObjectProperties>>
+    for Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>
+{
     fn from_c(value: &VecWrap<EquivalentObjectProperties>) -> Self {
         Vec::<horned_owl::model::EquivalentObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>> for VecWrap<EquivalentObjectProperties> {
+impl FromCompatible<&Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
+    for VecWrap<EquivalentObjectProperties>
+{
     fn from_c(value: &Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>) -> Self {
         VecWrap::<EquivalentObjectProperties>::from(value)
     }
@@ -10636,26 +11133,24 @@ impl FromCompatible<&Vec<horned_owl::model::EquivalentObjectProperties<ArcStr>>>
     "\n\n",
     doc!(DisjointObjectProperties)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DisjointObjectProperties (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DisjointObjectProperties(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<ObjectPropertyExpression>,
 );
 
 #[pymethods]
 impl DisjointObjectProperties {
     #[new]
-    fn new(first: VecWrap<ObjectPropertyExpression>,) -> Self {
-        DisjointObjectProperties (first,)
+    fn new(first: VecWrap<ObjectPropertyExpression>) -> Self {
+        DisjointObjectProperties(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -10668,9 +11163,10 @@ impl DisjointObjectProperties {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DisjointObjectProperties<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DisjointObjectProperties<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -10699,43 +11195,46 @@ impl DisjointObjectProperties {
 
 impl From<&horned_owl::model::DisjointObjectProperties<ArcStr>> for DisjointObjectProperties {
     fn from(value: &horned_owl::model::DisjointObjectProperties<ArcStr>) -> Self {
-
-        DisjointObjectProperties (
-    IntoCompatible::<VecWrap<ObjectPropertyExpression>>::into_c(&value.0),
-        )
+        DisjointObjectProperties(IntoCompatible::<VecWrap<ObjectPropertyExpression>>::into_c(
+            &value.0,
+        ))
     }
 }
 
 impl From<&DisjointObjectProperties> for horned_owl::model::DisjointObjectProperties<ArcStr> {
     fn from(value: &DisjointObjectProperties) -> Self {
-        horned_owl::model::DisjointObjectProperties::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DisjointObjectProperties::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for DisjointObjectProperties ****************/
-impl FromCompatible<horned_owl::model::DisjointObjectProperties<ArcStr>> for DisjointObjectProperties {
+impl FromCompatible<horned_owl::model::DisjointObjectProperties<ArcStr>>
+    for DisjointObjectProperties
+{
     fn from_c(value: horned_owl::model::DisjointObjectProperties<ArcStr>) -> Self {
         DisjointObjectProperties::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::DisjointObjectProperties<ArcStr>> for DisjointObjectProperties {
+impl FromCompatible<&horned_owl::model::DisjointObjectProperties<ArcStr>>
+    for DisjointObjectProperties
+{
     fn from_c(value: &horned_owl::model::DisjointObjectProperties<ArcStr>) -> Self {
         DisjointObjectProperties::from(value)
     }
 }
 
-impl FromCompatible<DisjointObjectProperties> for horned_owl::model::DisjointObjectProperties<ArcStr> {
+impl FromCompatible<DisjointObjectProperties>
+    for horned_owl::model::DisjointObjectProperties<ArcStr>
+{
     fn from_c(value: DisjointObjectProperties) -> Self {
         horned_owl::model::DisjointObjectProperties::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&DisjointObjectProperties> for horned_owl::model::DisjointObjectProperties<ArcStr> {
+impl FromCompatible<&DisjointObjectProperties>
+    for horned_owl::model::DisjointObjectProperties<ArcStr>
+{
     fn from_c(value: &DisjointObjectProperties) -> Self {
         horned_owl::model::DisjointObjectProperties::<ArcStr>::from(value)
     }
@@ -10753,43 +11252,59 @@ impl From<DisjointObjectProperties> for horned_owl::model::DisjointObjectPropert
     }
 }
 
-impl From<&BoxWrap<DisjointObjectProperties>> for Box<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl From<&BoxWrap<DisjointObjectProperties>>
+    for Box<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from(value: &BoxWrap<DisjointObjectProperties>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::DisjointObjectProperties<ArcStr>>> for BoxWrap<DisjointObjectProperties> {
+impl From<&Box<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for BoxWrap<DisjointObjectProperties>
+{
     fn from(value: &Box<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<DisjointObjectProperties>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<DisjointObjectProperties>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<DisjointObjectProperties>> for Box<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl From<BoxWrap<DisjointObjectProperties>>
+    for Box<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from(value: BoxWrap<DisjointObjectProperties>) -> Self {
         Into::<Box<horned_owl::model::DisjointObjectProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::DisjointObjectProperties<ArcStr>>> for BoxWrap<DisjointObjectProperties> {
+impl From<Box<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for BoxWrap<DisjointObjectProperties>
+{
     fn from(value: Box<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         Into::<BoxWrap<DisjointObjectProperties>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<DisjointObjectProperties>> for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl From<VecWrap<DisjointObjectProperties>>
+    for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from(value: VecWrap<DisjointObjectProperties>) -> Self {
         Into::<Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>> for VecWrap<DisjointObjectProperties> {
+impl From<Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for VecWrap<DisjointObjectProperties>
+{
     fn from(value: Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         Into::<VecWrap<DisjointObjectProperties>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<DisjointObjectProperties>> for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl From<&VecWrap<DisjointObjectProperties>>
+    for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from(value: &VecWrap<DisjointObjectProperties>) -> Self {
         value
             .0
@@ -10798,48 +11313,66 @@ impl From<&VecWrap<DisjointObjectProperties>> for Vec<horned_owl::model::Disjoin
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>> for VecWrap<DisjointObjectProperties> {
+impl From<&Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for VecWrap<DisjointObjectProperties>
+{
     fn from(value: &Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         VecWrap(value.iter().map(DisjointObjectProperties::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<DisjointObjectProperties>> for Box<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl FromCompatible<&BoxWrap<DisjointObjectProperties>>
+    for Box<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DisjointObjectProperties>) -> Self {
         Box::<horned_owl::model::DisjointObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DisjointObjectProperties<ArcStr>>> for BoxWrap<DisjointObjectProperties> {
+impl FromCompatible<&Box<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for BoxWrap<DisjointObjectProperties>
+{
     fn from_c(value: &Box<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         BoxWrap::<DisjointObjectProperties>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DisjointObjectProperties>> for Box<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl FromCompatible<BoxWrap<DisjointObjectProperties>>
+    for Box<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from_c(value: BoxWrap<DisjointObjectProperties>) -> Self {
         Box::<horned_owl::model::DisjointObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DisjointObjectProperties<ArcStr>>> for BoxWrap<DisjointObjectProperties> {
+impl FromCompatible<Box<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for BoxWrap<DisjointObjectProperties>
+{
     fn from_c(value: Box<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         BoxWrap::<DisjointObjectProperties>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DisjointObjectProperties>> for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl FromCompatible<VecWrap<DisjointObjectProperties>>
+    for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from_c(value: VecWrap<DisjointObjectProperties>) -> Self {
         Vec::<horned_owl::model::DisjointObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>> for VecWrap<DisjointObjectProperties> {
+impl FromCompatible<Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for VecWrap<DisjointObjectProperties>
+{
     fn from_c(value: Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         VecWrap::<DisjointObjectProperties>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DisjointObjectProperties>> for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>> {
+impl FromCompatible<&VecWrap<DisjointObjectProperties>>
+    for Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>
+{
     fn from_c(value: &VecWrap<DisjointObjectProperties>) -> Self {
         Vec::<horned_owl::model::DisjointObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>> for VecWrap<DisjointObjectProperties> {
+impl FromCompatible<&Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>>
+    for VecWrap<DisjointObjectProperties>
+{
     fn from_c(value: &Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>) -> Self {
         VecWrap::<DisjointObjectProperties>::from(value)
     }
@@ -10849,30 +11382,27 @@ impl FromCompatible<&Vec<horned_owl::model::DisjointObjectProperties<ArcStr>>> f
     "\n\n",
     doc!(InverseObjectProperties)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct InverseObjectProperties (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct InverseObjectProperties(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectProperty,
-    #[doc="second: "]
-    #[pyo3(get,set,name="second")]
+    #[doc = "second: "]
+    #[pyo3(get, set, name = "second")]
     pub ObjectProperty,
 );
 
 #[pymethods]
 impl InverseObjectProperties {
     #[new]
-    fn new(first: ObjectProperty,second: ObjectProperty,) -> Self {
-        InverseObjectProperties (first,second,)
+    fn new(first: ObjectProperty, second: ObjectProperty) -> Self {
+        InverseObjectProperties(first, second)
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "first".to_string(),
-            "second".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("first".to_string(), "second".to_string()))
     }
 
     fn __hash__(&self) -> u64 {
@@ -10885,9 +11415,10 @@ impl InverseObjectProperties {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::InverseObjectProperties<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::InverseObjectProperties<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -10916,45 +11447,50 @@ impl InverseObjectProperties {
 
 impl From<&horned_owl::model::InverseObjectProperties<ArcStr>> for InverseObjectProperties {
     fn from(value: &horned_owl::model::InverseObjectProperties<ArcStr>) -> Self {
-
-        InverseObjectProperties (
-    IntoCompatible::<ObjectProperty>::into_c(&value.0),
-    IntoCompatible::<ObjectProperty>::into_c(&value.1),
+        InverseObjectProperties(
+            IntoCompatible::<ObjectProperty>::into_c(&value.0),
+            IntoCompatible::<ObjectProperty>::into_c(&value.1),
         )
     }
 }
 
 impl From<&InverseObjectProperties> for horned_owl::model::InverseObjectProperties<ArcStr> {
     fn from(value: &InverseObjectProperties) -> Self {
-        horned_owl::model::InverseObjectProperties::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-    IntoCompatible::into_c(&value.1),
+        horned_owl::model::InverseObjectProperties::<ArcStr>(
+            IntoCompatible::into_c(&value.0),
+            IntoCompatible::into_c(&value.1),
         )
     }
 }
 
-
-
 /**************** Base implementations for InverseObjectProperties ****************/
-impl FromCompatible<horned_owl::model::InverseObjectProperties<ArcStr>> for InverseObjectProperties {
+impl FromCompatible<horned_owl::model::InverseObjectProperties<ArcStr>>
+    for InverseObjectProperties
+{
     fn from_c(value: horned_owl::model::InverseObjectProperties<ArcStr>) -> Self {
         InverseObjectProperties::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::InverseObjectProperties<ArcStr>> for InverseObjectProperties {
+impl FromCompatible<&horned_owl::model::InverseObjectProperties<ArcStr>>
+    for InverseObjectProperties
+{
     fn from_c(value: &horned_owl::model::InverseObjectProperties<ArcStr>) -> Self {
         InverseObjectProperties::from(value)
     }
 }
 
-impl FromCompatible<InverseObjectProperties> for horned_owl::model::InverseObjectProperties<ArcStr> {
+impl FromCompatible<InverseObjectProperties>
+    for horned_owl::model::InverseObjectProperties<ArcStr>
+{
     fn from_c(value: InverseObjectProperties) -> Self {
         horned_owl::model::InverseObjectProperties::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&InverseObjectProperties> for horned_owl::model::InverseObjectProperties<ArcStr> {
+impl FromCompatible<&InverseObjectProperties>
+    for horned_owl::model::InverseObjectProperties<ArcStr>
+{
     fn from_c(value: &InverseObjectProperties) -> Self {
         horned_owl::model::InverseObjectProperties::<ArcStr>::from(value)
     }
@@ -10972,43 +11508,59 @@ impl From<InverseObjectProperties> for horned_owl::model::InverseObjectPropertie
     }
 }
 
-impl From<&BoxWrap<InverseObjectProperties>> for Box<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl From<&BoxWrap<InverseObjectProperties>>
+    for Box<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from(value: &BoxWrap<InverseObjectProperties>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::InverseObjectProperties<ArcStr>>> for BoxWrap<InverseObjectProperties> {
+impl From<&Box<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for BoxWrap<InverseObjectProperties>
+{
     fn from(value: &Box<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<InverseObjectProperties>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<InverseObjectProperties>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<InverseObjectProperties>> for Box<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl From<BoxWrap<InverseObjectProperties>>
+    for Box<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from(value: BoxWrap<InverseObjectProperties>) -> Self {
         Into::<Box<horned_owl::model::InverseObjectProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::InverseObjectProperties<ArcStr>>> for BoxWrap<InverseObjectProperties> {
+impl From<Box<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for BoxWrap<InverseObjectProperties>
+{
     fn from(value: Box<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         Into::<BoxWrap<InverseObjectProperties>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<InverseObjectProperties>> for Vec<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl From<VecWrap<InverseObjectProperties>>
+    for Vec<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from(value: VecWrap<InverseObjectProperties>) -> Self {
         Into::<Vec<horned_owl::model::InverseObjectProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::InverseObjectProperties<ArcStr>>> for VecWrap<InverseObjectProperties> {
+impl From<Vec<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for VecWrap<InverseObjectProperties>
+{
     fn from(value: Vec<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         Into::<VecWrap<InverseObjectProperties>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<InverseObjectProperties>> for Vec<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl From<&VecWrap<InverseObjectProperties>>
+    for Vec<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from(value: &VecWrap<InverseObjectProperties>) -> Self {
         value
             .0
@@ -11017,48 +11569,66 @@ impl From<&VecWrap<InverseObjectProperties>> for Vec<horned_owl::model::InverseO
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::InverseObjectProperties<ArcStr>>> for VecWrap<InverseObjectProperties> {
+impl From<&Vec<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for VecWrap<InverseObjectProperties>
+{
     fn from(value: &Vec<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         VecWrap(value.iter().map(InverseObjectProperties::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<InverseObjectProperties>> for Box<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl FromCompatible<&BoxWrap<InverseObjectProperties>>
+    for Box<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from_c(value: &BoxWrap<InverseObjectProperties>) -> Self {
         Box::<horned_owl::model::InverseObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::InverseObjectProperties<ArcStr>>> for BoxWrap<InverseObjectProperties> {
+impl FromCompatible<&Box<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for BoxWrap<InverseObjectProperties>
+{
     fn from_c(value: &Box<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         BoxWrap::<InverseObjectProperties>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<InverseObjectProperties>> for Box<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl FromCompatible<BoxWrap<InverseObjectProperties>>
+    for Box<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from_c(value: BoxWrap<InverseObjectProperties>) -> Self {
         Box::<horned_owl::model::InverseObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::InverseObjectProperties<ArcStr>>> for BoxWrap<InverseObjectProperties> {
+impl FromCompatible<Box<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for BoxWrap<InverseObjectProperties>
+{
     fn from_c(value: Box<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         BoxWrap::<InverseObjectProperties>::from(value)
     }
 }
-impl FromCompatible<VecWrap<InverseObjectProperties>> for Vec<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl FromCompatible<VecWrap<InverseObjectProperties>>
+    for Vec<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from_c(value: VecWrap<InverseObjectProperties>) -> Self {
         Vec::<horned_owl::model::InverseObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::InverseObjectProperties<ArcStr>>> for VecWrap<InverseObjectProperties> {
+impl FromCompatible<Vec<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for VecWrap<InverseObjectProperties>
+{
     fn from_c(value: Vec<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         VecWrap::<InverseObjectProperties>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<InverseObjectProperties>> for Vec<horned_owl::model::InverseObjectProperties<ArcStr>> {
+impl FromCompatible<&VecWrap<InverseObjectProperties>>
+    for Vec<horned_owl::model::InverseObjectProperties<ArcStr>>
+{
     fn from_c(value: &VecWrap<InverseObjectProperties>) -> Self {
         Vec::<horned_owl::model::InverseObjectProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::InverseObjectProperties<ArcStr>>> for VecWrap<InverseObjectProperties> {
+impl FromCompatible<&Vec<horned_owl::model::InverseObjectProperties<ArcStr>>>
+    for VecWrap<InverseObjectProperties>
+{
     fn from_c(value: &Vec<horned_owl::model::InverseObjectProperties<ArcStr>>) -> Self {
         VecWrap::<InverseObjectProperties>::from(value)
     }
@@ -11067,41 +11637,38 @@ impl FromCompatible<&Vec<horned_owl::model::InverseObjectProperties<ArcStr>>> fo
     "\n\n",
     doc!(ObjectPropertyDomain)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectPropertyDomain {
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-    
-        #[doc="ce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub ce: ClassExpression,
-    }
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+
+    #[doc = "ce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub ce: ClassExpression,
+}
 
 #[pymethods]
 impl ObjectPropertyDomain {
     #[new]
-    fn new(ope: ObjectPropertyExpression,ce: ClassExpression,) -> Self {
-        ObjectPropertyDomain {
-                ope,
-                ce,
-        }
+    fn new(ope: ObjectPropertyExpression, ce: ClassExpression) -> Self {
+        ObjectPropertyDomain { ope, ce }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "ope".to_string(),
-            "ce".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ope".to_string(), "ce".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any),
             "ce" => self.ce.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -11110,12 +11677,15 @@ impl ObjectPropertyDomain {
             "ope" => {
                 self.ope = value.extract()?;
                 Ok(())
-            },
+            }
             "ce" => {
                 self.ce = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -11129,9 +11699,10 @@ impl ObjectPropertyDomain {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::ObjectPropertyDomain<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::ObjectPropertyDomain<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -11167,7 +11738,6 @@ impl From<&horned_owl::model::ObjectPropertyDomain<ArcStr>> for ObjectPropertyDo
     }
 }
 
-
 impl From<&ObjectPropertyDomain> for horned_owl::model::ObjectPropertyDomain<ArcStr> {
     fn from(value: &ObjectPropertyDomain) -> Self {
         horned_owl::model::ObjectPropertyDomain::<ArcStr> {
@@ -11176,8 +11746,6 @@ impl From<&ObjectPropertyDomain> for horned_owl::model::ObjectPropertyDomain<Arc
         }
     }
 }
-
-
 
 /**************** Base implementations for ObjectPropertyDomain ****************/
 impl FromCompatible<horned_owl::model::ObjectPropertyDomain<ArcStr>> for ObjectPropertyDomain {
@@ -11267,42 +11835,58 @@ impl From<&Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>> for VecWrap<Obj
     }
 }
 
-impl FromCompatible<&BoxWrap<ObjectPropertyDomain>> for Box<horned_owl::model::ObjectPropertyDomain<ArcStr>> {
+impl FromCompatible<&BoxWrap<ObjectPropertyDomain>>
+    for Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>
+{
     fn from_c(value: &BoxWrap<ObjectPropertyDomain>) -> Self {
         Box::<horned_owl::model::ObjectPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>> for BoxWrap<ObjectPropertyDomain> {
+impl FromCompatible<&Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>>
+    for BoxWrap<ObjectPropertyDomain>
+{
     fn from_c(value: &Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<ObjectPropertyDomain>> for Box<horned_owl::model::ObjectPropertyDomain<ArcStr>> {
+impl FromCompatible<BoxWrap<ObjectPropertyDomain>>
+    for Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>
+{
     fn from_c(value: BoxWrap<ObjectPropertyDomain>) -> Self {
         Box::<horned_owl::model::ObjectPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>> for BoxWrap<ObjectPropertyDomain> {
+impl FromCompatible<Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>>
+    for BoxWrap<ObjectPropertyDomain>
+{
     fn from_c(value: Box<horned_owl::model::ObjectPropertyDomain<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<VecWrap<ObjectPropertyDomain>> for Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>> {
+impl FromCompatible<VecWrap<ObjectPropertyDomain>>
+    for Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>
+{
     fn from_c(value: VecWrap<ObjectPropertyDomain>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>> for VecWrap<ObjectPropertyDomain> {
+impl FromCompatible<Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>>
+    for VecWrap<ObjectPropertyDomain>
+{
     fn from_c(value: Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<ObjectPropertyDomain>> for Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>> {
+impl FromCompatible<&VecWrap<ObjectPropertyDomain>>
+    for Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>
+{
     fn from_c(value: &VecWrap<ObjectPropertyDomain>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>> for VecWrap<ObjectPropertyDomain> {
+impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>>
+    for VecWrap<ObjectPropertyDomain>
+{
     fn from_c(value: &Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyDomain>::from(value)
     }
@@ -11311,41 +11895,38 @@ impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyDomain<ArcStr>>> for V
     "\n\n",
     doc!(ObjectPropertyRange)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectPropertyRange {
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-    
-        #[doc="ce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub ce: ClassExpression,
-    }
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+
+    #[doc = "ce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub ce: ClassExpression,
+}
 
 #[pymethods]
 impl ObjectPropertyRange {
     #[new]
-    fn new(ope: ObjectPropertyExpression,ce: ClassExpression,) -> Self {
-        ObjectPropertyRange {
-                ope,
-                ce,
-        }
+    fn new(ope: ObjectPropertyExpression, ce: ClassExpression) -> Self {
+        ObjectPropertyRange { ope, ce }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "ope".to_string(),
-            "ce".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ope".to_string(), "ce".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any),
             "ce" => self.ce.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -11354,12 +11935,15 @@ impl ObjectPropertyRange {
             "ope" => {
                 self.ope = value.extract()?;
                 Ok(())
-            },
+            }
             "ce" => {
                 self.ce = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -11373,9 +11957,10 @@ impl ObjectPropertyRange {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::ObjectPropertyRange<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::ObjectPropertyRange<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -11411,7 +11996,6 @@ impl From<&horned_owl::model::ObjectPropertyRange<ArcStr>> for ObjectPropertyRan
     }
 }
 
-
 impl From<&ObjectPropertyRange> for horned_owl::model::ObjectPropertyRange<ArcStr> {
     fn from(value: &ObjectPropertyRange) -> Self {
         horned_owl::model::ObjectPropertyRange::<ArcStr> {
@@ -11420,8 +12004,6 @@ impl From<&ObjectPropertyRange> for horned_owl::model::ObjectPropertyRange<ArcSt
         }
     }
 }
-
-
 
 /**************** Base implementations for ObjectPropertyRange ****************/
 impl FromCompatible<horned_owl::model::ObjectPropertyRange<ArcStr>> for ObjectPropertyRange {
@@ -11511,42 +12093,58 @@ impl From<&Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>> for VecWrap<Obje
     }
 }
 
-impl FromCompatible<&BoxWrap<ObjectPropertyRange>> for Box<horned_owl::model::ObjectPropertyRange<ArcStr>> {
+impl FromCompatible<&BoxWrap<ObjectPropertyRange>>
+    for Box<horned_owl::model::ObjectPropertyRange<ArcStr>>
+{
     fn from_c(value: &BoxWrap<ObjectPropertyRange>) -> Self {
         Box::<horned_owl::model::ObjectPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::ObjectPropertyRange<ArcStr>>> for BoxWrap<ObjectPropertyRange> {
+impl FromCompatible<&Box<horned_owl::model::ObjectPropertyRange<ArcStr>>>
+    for BoxWrap<ObjectPropertyRange>
+{
     fn from_c(value: &Box<horned_owl::model::ObjectPropertyRange<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyRange>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<ObjectPropertyRange>> for Box<horned_owl::model::ObjectPropertyRange<ArcStr>> {
+impl FromCompatible<BoxWrap<ObjectPropertyRange>>
+    for Box<horned_owl::model::ObjectPropertyRange<ArcStr>>
+{
     fn from_c(value: BoxWrap<ObjectPropertyRange>) -> Self {
         Box::<horned_owl::model::ObjectPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::ObjectPropertyRange<ArcStr>>> for BoxWrap<ObjectPropertyRange> {
+impl FromCompatible<Box<horned_owl::model::ObjectPropertyRange<ArcStr>>>
+    for BoxWrap<ObjectPropertyRange>
+{
     fn from_c(value: Box<horned_owl::model::ObjectPropertyRange<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyRange>::from(value)
     }
 }
-impl FromCompatible<VecWrap<ObjectPropertyRange>> for Vec<horned_owl::model::ObjectPropertyRange<ArcStr>> {
+impl FromCompatible<VecWrap<ObjectPropertyRange>>
+    for Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>
+{
     fn from_c(value: VecWrap<ObjectPropertyRange>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>> for VecWrap<ObjectPropertyRange> {
+impl FromCompatible<Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>>
+    for VecWrap<ObjectPropertyRange>
+{
     fn from_c(value: Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyRange>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<ObjectPropertyRange>> for Vec<horned_owl::model::ObjectPropertyRange<ArcStr>> {
+impl FromCompatible<&VecWrap<ObjectPropertyRange>>
+    for Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>
+{
     fn from_c(value: &VecWrap<ObjectPropertyRange>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>> for VecWrap<ObjectPropertyRange> {
+impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>>
+    for VecWrap<ObjectPropertyRange>
+{
     fn from_c(value: &Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyRange>::from(value)
     }
@@ -11556,26 +12154,24 @@ impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyRange<ArcStr>>> for Ve
     "\n\n",
     doc!(FunctionalObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FunctionalObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct FunctionalObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl FunctionalObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        FunctionalObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        FunctionalObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -11588,9 +12184,10 @@ impl FunctionalObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::FunctionalObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::FunctionalObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -11619,43 +12216,44 @@ impl FunctionalObjectProperty {
 
 impl From<&horned_owl::model::FunctionalObjectProperty<ArcStr>> for FunctionalObjectProperty {
     fn from(value: &horned_owl::model::FunctionalObjectProperty<ArcStr>) -> Self {
-
-        FunctionalObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        FunctionalObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0))
     }
 }
 
 impl From<&FunctionalObjectProperty> for horned_owl::model::FunctionalObjectProperty<ArcStr> {
     fn from(value: &FunctionalObjectProperty) -> Self {
-        horned_owl::model::FunctionalObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::FunctionalObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for FunctionalObjectProperty ****************/
-impl FromCompatible<horned_owl::model::FunctionalObjectProperty<ArcStr>> for FunctionalObjectProperty {
+impl FromCompatible<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+    for FunctionalObjectProperty
+{
     fn from_c(value: horned_owl::model::FunctionalObjectProperty<ArcStr>) -> Self {
         FunctionalObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::FunctionalObjectProperty<ArcStr>> for FunctionalObjectProperty {
+impl FromCompatible<&horned_owl::model::FunctionalObjectProperty<ArcStr>>
+    for FunctionalObjectProperty
+{
     fn from_c(value: &horned_owl::model::FunctionalObjectProperty<ArcStr>) -> Self {
         FunctionalObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<FunctionalObjectProperty> for horned_owl::model::FunctionalObjectProperty<ArcStr> {
+impl FromCompatible<FunctionalObjectProperty>
+    for horned_owl::model::FunctionalObjectProperty<ArcStr>
+{
     fn from_c(value: FunctionalObjectProperty) -> Self {
         horned_owl::model::FunctionalObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&FunctionalObjectProperty> for horned_owl::model::FunctionalObjectProperty<ArcStr> {
+impl FromCompatible<&FunctionalObjectProperty>
+    for horned_owl::model::FunctionalObjectProperty<ArcStr>
+{
     fn from_c(value: &FunctionalObjectProperty) -> Self {
         horned_owl::model::FunctionalObjectProperty::<ArcStr>::from(value)
     }
@@ -11673,43 +12271,59 @@ impl From<FunctionalObjectProperty> for horned_owl::model::FunctionalObjectPrope
     }
 }
 
-impl From<&BoxWrap<FunctionalObjectProperty>> for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl From<&BoxWrap<FunctionalObjectProperty>>
+    for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<FunctionalObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for BoxWrap<FunctionalObjectProperty> {
+impl From<&Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<FunctionalObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<FunctionalObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<FunctionalObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<FunctionalObjectProperty>> for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl From<BoxWrap<FunctionalObjectProperty>>
+    for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<FunctionalObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for BoxWrap<FunctionalObjectProperty> {
+impl From<Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<FunctionalObjectProperty>
+{
     fn from(value: Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<FunctionalObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<FunctionalObjectProperty>> for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl From<VecWrap<FunctionalObjectProperty>>
+    for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<FunctionalObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for VecWrap<FunctionalObjectProperty> {
+impl From<Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for VecWrap<FunctionalObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<FunctionalObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<FunctionalObjectProperty>> for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl From<&VecWrap<FunctionalObjectProperty>>
+    for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<FunctionalObjectProperty>) -> Self {
         value
             .0
@@ -11718,48 +12332,66 @@ impl From<&VecWrap<FunctionalObjectProperty>> for Vec<horned_owl::model::Functio
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for VecWrap<FunctionalObjectProperty> {
+impl From<&Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for VecWrap<FunctionalObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(FunctionalObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<FunctionalObjectProperty>> for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<FunctionalObjectProperty>>
+    for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<FunctionalObjectProperty>) -> Self {
         Box::<horned_owl::model::FunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for BoxWrap<FunctionalObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<FunctionalObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<FunctionalObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<FunctionalObjectProperty>> for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<FunctionalObjectProperty>>
+    for Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<FunctionalObjectProperty>) -> Self {
         Box::<horned_owl::model::FunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for BoxWrap<FunctionalObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<FunctionalObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<FunctionalObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<FunctionalObjectProperty>> for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<FunctionalObjectProperty>>
+    for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<FunctionalObjectProperty>) -> Self {
         Vec::<horned_owl::model::FunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for VecWrap<FunctionalObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for VecWrap<FunctionalObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         VecWrap::<FunctionalObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<FunctionalObjectProperty>> for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<FunctionalObjectProperty>>
+    for Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<FunctionalObjectProperty>) -> Self {
         Vec::<horned_owl::model::FunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>> for VecWrap<FunctionalObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>>
+    for VecWrap<FunctionalObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>) -> Self {
         VecWrap::<FunctionalObjectProperty>::from(value)
     }
@@ -11769,26 +12401,24 @@ impl FromCompatible<&Vec<horned_owl::model::FunctionalObjectProperty<ArcStr>>> f
     "\n\n",
     doc!(InverseFunctionalObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct InverseFunctionalObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct InverseFunctionalObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl InverseFunctionalObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        InverseFunctionalObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        InverseFunctionalObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -11801,9 +12431,10 @@ impl InverseFunctionalObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -11830,99 +12461,132 @@ impl InverseFunctionalObjectProperty {
     }
 }
 
-impl From<&horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> for InverseFunctionalObjectProperty {
+impl From<&horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+    for InverseFunctionalObjectProperty
+{
     fn from(value: &horned_owl::model::InverseFunctionalObjectProperty<ArcStr>) -> Self {
-
-        InverseFunctionalObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        InverseFunctionalObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(
+            &value.0,
+        ))
     }
 }
 
-impl From<&InverseFunctionalObjectProperty> for horned_owl::model::InverseFunctionalObjectProperty<ArcStr> {
+impl From<&InverseFunctionalObjectProperty>
+    for horned_owl::model::InverseFunctionalObjectProperty<ArcStr>
+{
     fn from(value: &InverseFunctionalObjectProperty) -> Self {
-        horned_owl::model::InverseFunctionalObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::InverseFunctionalObjectProperty::<ArcStr>(IntoCompatible::into_c(
+            &value.0,
+        ))
     }
 }
-
-
 
 /**************** Base implementations for InverseFunctionalObjectProperty ****************/
-impl FromCompatible<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> for InverseFunctionalObjectProperty {
+impl FromCompatible<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+    for InverseFunctionalObjectProperty
+{
     fn from_c(value: horned_owl::model::InverseFunctionalObjectProperty<ArcStr>) -> Self {
         InverseFunctionalObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> for InverseFunctionalObjectProperty {
+impl FromCompatible<&horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+    for InverseFunctionalObjectProperty
+{
     fn from_c(value: &horned_owl::model::InverseFunctionalObjectProperty<ArcStr>) -> Self {
         InverseFunctionalObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<InverseFunctionalObjectProperty> for horned_owl::model::InverseFunctionalObjectProperty<ArcStr> {
+impl FromCompatible<InverseFunctionalObjectProperty>
+    for horned_owl::model::InverseFunctionalObjectProperty<ArcStr>
+{
     fn from_c(value: InverseFunctionalObjectProperty) -> Self {
         horned_owl::model::InverseFunctionalObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&InverseFunctionalObjectProperty> for horned_owl::model::InverseFunctionalObjectProperty<ArcStr> {
+impl FromCompatible<&InverseFunctionalObjectProperty>
+    for horned_owl::model::InverseFunctionalObjectProperty<ArcStr>
+{
     fn from_c(value: &InverseFunctionalObjectProperty) -> Self {
         horned_owl::model::InverseFunctionalObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl From<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> for InverseFunctionalObjectProperty {
+impl From<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+    for InverseFunctionalObjectProperty
+{
     fn from(value: horned_owl::model::InverseFunctionalObjectProperty<ArcStr>) -> Self {
         InverseFunctionalObjectProperty::from(value.borrow())
     }
 }
 
-impl From<InverseFunctionalObjectProperty> for horned_owl::model::InverseFunctionalObjectProperty<ArcStr> {
+impl From<InverseFunctionalObjectProperty>
+    for horned_owl::model::InverseFunctionalObjectProperty<ArcStr>
+{
     fn from(value: InverseFunctionalObjectProperty) -> Self {
         horned_owl::model::InverseFunctionalObjectProperty::<ArcStr>::from(value.borrow())
     }
 }
 
-impl From<&BoxWrap<InverseFunctionalObjectProperty>> for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl From<&BoxWrap<InverseFunctionalObjectProperty>>
+    for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<InverseFunctionalObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for BoxWrap<InverseFunctionalObjectProperty> {
+impl From<&Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<InverseFunctionalObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<InverseFunctionalObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<InverseFunctionalObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<InverseFunctionalObjectProperty>> for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl From<BoxWrap<InverseFunctionalObjectProperty>>
+    for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<InverseFunctionalObjectProperty>) -> Self {
-        Into::<Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>::into(value.borrow())
+        Into::<Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>::into(
+            value.borrow(),
+        )
     }
 }
 
-impl From<Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for BoxWrap<InverseFunctionalObjectProperty> {
+impl From<Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<InverseFunctionalObjectProperty>
+{
     fn from(value: Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<InverseFunctionalObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<InverseFunctionalObjectProperty>> for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl From<VecWrap<InverseFunctionalObjectProperty>>
+    for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<InverseFunctionalObjectProperty>) -> Self {
-        Into::<Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>::into(value.borrow())
+        Into::<Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>::into(
+            value.borrow(),
+        )
     }
 }
 
-impl From<Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for VecWrap<InverseFunctionalObjectProperty> {
+impl From<Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for VecWrap<InverseFunctionalObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<InverseFunctionalObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<InverseFunctionalObjectProperty>> for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl From<&VecWrap<InverseFunctionalObjectProperty>>
+    for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<InverseFunctionalObjectProperty>) -> Self {
         value
             .0
@@ -11931,48 +12595,71 @@ impl From<&VecWrap<InverseFunctionalObjectProperty>> for Vec<horned_owl::model::
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for VecWrap<InverseFunctionalObjectProperty> {
+impl From<&Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for VecWrap<InverseFunctionalObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
-        VecWrap(value.iter().map(InverseFunctionalObjectProperty::from).collect())
+        VecWrap(
+            value
+                .iter()
+                .map(InverseFunctionalObjectProperty::from)
+                .collect(),
+        )
     }
 }
 
-impl FromCompatible<&BoxWrap<InverseFunctionalObjectProperty>> for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<InverseFunctionalObjectProperty>>
+    for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<InverseFunctionalObjectProperty>) -> Self {
         Box::<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for BoxWrap<InverseFunctionalObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<InverseFunctionalObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<InverseFunctionalObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<InverseFunctionalObjectProperty>> for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<InverseFunctionalObjectProperty>>
+    for Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<InverseFunctionalObjectProperty>) -> Self {
         Box::<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for BoxWrap<InverseFunctionalObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for BoxWrap<InverseFunctionalObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<InverseFunctionalObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<InverseFunctionalObjectProperty>> for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<InverseFunctionalObjectProperty>>
+    for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<InverseFunctionalObjectProperty>) -> Self {
         Vec::<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for VecWrap<InverseFunctionalObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for VecWrap<InverseFunctionalObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
         VecWrap::<InverseFunctionalObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<InverseFunctionalObjectProperty>> for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<InverseFunctionalObjectProperty>>
+    for Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<InverseFunctionalObjectProperty>) -> Self {
         Vec::<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>> for VecWrap<InverseFunctionalObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>>
+    for VecWrap<InverseFunctionalObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcStr>>) -> Self {
         VecWrap::<InverseFunctionalObjectProperty>::from(value)
     }
@@ -11982,26 +12669,24 @@ impl FromCompatible<&Vec<horned_owl::model::InverseFunctionalObjectProperty<ArcS
     "\n\n",
     doc!(ReflexiveObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct ReflexiveObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct ReflexiveObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl ReflexiveObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        ReflexiveObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        ReflexiveObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -12014,9 +12699,10 @@ impl ReflexiveObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::ReflexiveObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::ReflexiveObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -12045,43 +12731,44 @@ impl ReflexiveObjectProperty {
 
 impl From<&horned_owl::model::ReflexiveObjectProperty<ArcStr>> for ReflexiveObjectProperty {
     fn from(value: &horned_owl::model::ReflexiveObjectProperty<ArcStr>) -> Self {
-
-        ReflexiveObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        ReflexiveObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0))
     }
 }
 
 impl From<&ReflexiveObjectProperty> for horned_owl::model::ReflexiveObjectProperty<ArcStr> {
     fn from(value: &ReflexiveObjectProperty) -> Self {
-        horned_owl::model::ReflexiveObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::ReflexiveObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for ReflexiveObjectProperty ****************/
-impl FromCompatible<horned_owl::model::ReflexiveObjectProperty<ArcStr>> for ReflexiveObjectProperty {
+impl FromCompatible<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+    for ReflexiveObjectProperty
+{
     fn from_c(value: horned_owl::model::ReflexiveObjectProperty<ArcStr>) -> Self {
         ReflexiveObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::ReflexiveObjectProperty<ArcStr>> for ReflexiveObjectProperty {
+impl FromCompatible<&horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+    for ReflexiveObjectProperty
+{
     fn from_c(value: &horned_owl::model::ReflexiveObjectProperty<ArcStr>) -> Self {
         ReflexiveObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<ReflexiveObjectProperty> for horned_owl::model::ReflexiveObjectProperty<ArcStr> {
+impl FromCompatible<ReflexiveObjectProperty>
+    for horned_owl::model::ReflexiveObjectProperty<ArcStr>
+{
     fn from_c(value: ReflexiveObjectProperty) -> Self {
         horned_owl::model::ReflexiveObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&ReflexiveObjectProperty> for horned_owl::model::ReflexiveObjectProperty<ArcStr> {
+impl FromCompatible<&ReflexiveObjectProperty>
+    for horned_owl::model::ReflexiveObjectProperty<ArcStr>
+{
     fn from_c(value: &ReflexiveObjectProperty) -> Self {
         horned_owl::model::ReflexiveObjectProperty::<ArcStr>::from(value)
     }
@@ -12099,43 +12786,59 @@ impl From<ReflexiveObjectProperty> for horned_owl::model::ReflexiveObjectPropert
     }
 }
 
-impl From<&BoxWrap<ReflexiveObjectProperty>> for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl From<&BoxWrap<ReflexiveObjectProperty>>
+    for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<ReflexiveObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for BoxWrap<ReflexiveObjectProperty> {
+impl From<&Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<ReflexiveObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<ReflexiveObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<ReflexiveObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<ReflexiveObjectProperty>> for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl From<BoxWrap<ReflexiveObjectProperty>>
+    for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<ReflexiveObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for BoxWrap<ReflexiveObjectProperty> {
+impl From<Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<ReflexiveObjectProperty>
+{
     fn from(value: Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<ReflexiveObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<ReflexiveObjectProperty>> for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl From<VecWrap<ReflexiveObjectProperty>>
+    for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<ReflexiveObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for VecWrap<ReflexiveObjectProperty> {
+impl From<Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for VecWrap<ReflexiveObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<ReflexiveObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<ReflexiveObjectProperty>> for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl From<&VecWrap<ReflexiveObjectProperty>>
+    for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<ReflexiveObjectProperty>) -> Self {
         value
             .0
@@ -12144,48 +12847,66 @@ impl From<&VecWrap<ReflexiveObjectProperty>> for Vec<horned_owl::model::Reflexiv
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for VecWrap<ReflexiveObjectProperty> {
+impl From<&Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for VecWrap<ReflexiveObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(ReflexiveObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<ReflexiveObjectProperty>> for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<ReflexiveObjectProperty>>
+    for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<ReflexiveObjectProperty>) -> Self {
         Box::<horned_owl::model::ReflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for BoxWrap<ReflexiveObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<ReflexiveObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<ReflexiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<ReflexiveObjectProperty>> for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<ReflexiveObjectProperty>>
+    for Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<ReflexiveObjectProperty>) -> Self {
         Box::<horned_owl::model::ReflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for BoxWrap<ReflexiveObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<ReflexiveObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<ReflexiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<ReflexiveObjectProperty>> for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<ReflexiveObjectProperty>>
+    for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<ReflexiveObjectProperty>) -> Self {
         Vec::<horned_owl::model::ReflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for VecWrap<ReflexiveObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for VecWrap<ReflexiveObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         VecWrap::<ReflexiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<ReflexiveObjectProperty>> for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<ReflexiveObjectProperty>>
+    for Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<ReflexiveObjectProperty>) -> Self {
         Vec::<horned_owl::model::ReflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> for VecWrap<ReflexiveObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>>
+    for VecWrap<ReflexiveObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>) -> Self {
         VecWrap::<ReflexiveObjectProperty>::from(value)
     }
@@ -12195,26 +12916,24 @@ impl FromCompatible<&Vec<horned_owl::model::ReflexiveObjectProperty<ArcStr>>> fo
     "\n\n",
     doc!(IrreflexiveObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct IrreflexiveObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct IrreflexiveObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl IrreflexiveObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        IrreflexiveObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        IrreflexiveObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -12227,9 +12946,10 @@ impl IrreflexiveObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -12258,43 +12978,44 @@ impl IrreflexiveObjectProperty {
 
 impl From<&horned_owl::model::IrreflexiveObjectProperty<ArcStr>> for IrreflexiveObjectProperty {
     fn from(value: &horned_owl::model::IrreflexiveObjectProperty<ArcStr>) -> Self {
-
-        IrreflexiveObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        IrreflexiveObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0))
     }
 }
 
 impl From<&IrreflexiveObjectProperty> for horned_owl::model::IrreflexiveObjectProperty<ArcStr> {
     fn from(value: &IrreflexiveObjectProperty) -> Self {
-        horned_owl::model::IrreflexiveObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::IrreflexiveObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for IrreflexiveObjectProperty ****************/
-impl FromCompatible<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> for IrreflexiveObjectProperty {
+impl FromCompatible<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+    for IrreflexiveObjectProperty
+{
     fn from_c(value: horned_owl::model::IrreflexiveObjectProperty<ArcStr>) -> Self {
         IrreflexiveObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::IrreflexiveObjectProperty<ArcStr>> for IrreflexiveObjectProperty {
+impl FromCompatible<&horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+    for IrreflexiveObjectProperty
+{
     fn from_c(value: &horned_owl::model::IrreflexiveObjectProperty<ArcStr>) -> Self {
         IrreflexiveObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<IrreflexiveObjectProperty> for horned_owl::model::IrreflexiveObjectProperty<ArcStr> {
+impl FromCompatible<IrreflexiveObjectProperty>
+    for horned_owl::model::IrreflexiveObjectProperty<ArcStr>
+{
     fn from_c(value: IrreflexiveObjectProperty) -> Self {
         horned_owl::model::IrreflexiveObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&IrreflexiveObjectProperty> for horned_owl::model::IrreflexiveObjectProperty<ArcStr> {
+impl FromCompatible<&IrreflexiveObjectProperty>
+    for horned_owl::model::IrreflexiveObjectProperty<ArcStr>
+{
     fn from_c(value: &IrreflexiveObjectProperty) -> Self {
         horned_owl::model::IrreflexiveObjectProperty::<ArcStr>::from(value)
     }
@@ -12312,43 +13033,59 @@ impl From<IrreflexiveObjectProperty> for horned_owl::model::IrreflexiveObjectPro
     }
 }
 
-impl From<&BoxWrap<IrreflexiveObjectProperty>> for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl From<&BoxWrap<IrreflexiveObjectProperty>>
+    for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<IrreflexiveObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for BoxWrap<IrreflexiveObjectProperty> {
+impl From<&Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<IrreflexiveObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<IrreflexiveObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<IrreflexiveObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<IrreflexiveObjectProperty>> for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl From<BoxWrap<IrreflexiveObjectProperty>>
+    for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<IrreflexiveObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for BoxWrap<IrreflexiveObjectProperty> {
+impl From<Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<IrreflexiveObjectProperty>
+{
     fn from(value: Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<IrreflexiveObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<IrreflexiveObjectProperty>> for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl From<VecWrap<IrreflexiveObjectProperty>>
+    for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<IrreflexiveObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for VecWrap<IrreflexiveObjectProperty> {
+impl From<Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for VecWrap<IrreflexiveObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<IrreflexiveObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<IrreflexiveObjectProperty>> for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl From<&VecWrap<IrreflexiveObjectProperty>>
+    for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<IrreflexiveObjectProperty>) -> Self {
         value
             .0
@@ -12357,48 +13094,66 @@ impl From<&VecWrap<IrreflexiveObjectProperty>> for Vec<horned_owl::model::Irrefl
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for VecWrap<IrreflexiveObjectProperty> {
+impl From<&Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for VecWrap<IrreflexiveObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(IrreflexiveObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<IrreflexiveObjectProperty>> for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<IrreflexiveObjectProperty>>
+    for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<IrreflexiveObjectProperty>) -> Self {
         Box::<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for BoxWrap<IrreflexiveObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<IrreflexiveObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<IrreflexiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<IrreflexiveObjectProperty>> for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<IrreflexiveObjectProperty>>
+    for Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<IrreflexiveObjectProperty>) -> Self {
         Box::<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for BoxWrap<IrreflexiveObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for BoxWrap<IrreflexiveObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<IrreflexiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<IrreflexiveObjectProperty>> for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<IrreflexiveObjectProperty>>
+    for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<IrreflexiveObjectProperty>) -> Self {
         Vec::<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for VecWrap<IrreflexiveObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for VecWrap<IrreflexiveObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         VecWrap::<IrreflexiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<IrreflexiveObjectProperty>> for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<IrreflexiveObjectProperty>>
+    for Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<IrreflexiveObjectProperty>) -> Self {
         Vec::<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> for VecWrap<IrreflexiveObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>>
+    for VecWrap<IrreflexiveObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>) -> Self {
         VecWrap::<IrreflexiveObjectProperty>::from(value)
     }
@@ -12408,26 +13163,24 @@ impl FromCompatible<&Vec<horned_owl::model::IrreflexiveObjectProperty<ArcStr>>> 
     "\n\n",
     doc!(SymmetricObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SymmetricObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct SymmetricObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl SymmetricObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        SymmetricObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        SymmetricObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -12440,9 +13193,10 @@ impl SymmetricObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::SymmetricObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::SymmetricObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -12471,43 +13225,44 @@ impl SymmetricObjectProperty {
 
 impl From<&horned_owl::model::SymmetricObjectProperty<ArcStr>> for SymmetricObjectProperty {
     fn from(value: &horned_owl::model::SymmetricObjectProperty<ArcStr>) -> Self {
-
-        SymmetricObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        SymmetricObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0))
     }
 }
 
 impl From<&SymmetricObjectProperty> for horned_owl::model::SymmetricObjectProperty<ArcStr> {
     fn from(value: &SymmetricObjectProperty) -> Self {
-        horned_owl::model::SymmetricObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::SymmetricObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for SymmetricObjectProperty ****************/
-impl FromCompatible<horned_owl::model::SymmetricObjectProperty<ArcStr>> for SymmetricObjectProperty {
+impl FromCompatible<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+    for SymmetricObjectProperty
+{
     fn from_c(value: horned_owl::model::SymmetricObjectProperty<ArcStr>) -> Self {
         SymmetricObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::SymmetricObjectProperty<ArcStr>> for SymmetricObjectProperty {
+impl FromCompatible<&horned_owl::model::SymmetricObjectProperty<ArcStr>>
+    for SymmetricObjectProperty
+{
     fn from_c(value: &horned_owl::model::SymmetricObjectProperty<ArcStr>) -> Self {
         SymmetricObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<SymmetricObjectProperty> for horned_owl::model::SymmetricObjectProperty<ArcStr> {
+impl FromCompatible<SymmetricObjectProperty>
+    for horned_owl::model::SymmetricObjectProperty<ArcStr>
+{
     fn from_c(value: SymmetricObjectProperty) -> Self {
         horned_owl::model::SymmetricObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&SymmetricObjectProperty> for horned_owl::model::SymmetricObjectProperty<ArcStr> {
+impl FromCompatible<&SymmetricObjectProperty>
+    for horned_owl::model::SymmetricObjectProperty<ArcStr>
+{
     fn from_c(value: &SymmetricObjectProperty) -> Self {
         horned_owl::model::SymmetricObjectProperty::<ArcStr>::from(value)
     }
@@ -12525,43 +13280,59 @@ impl From<SymmetricObjectProperty> for horned_owl::model::SymmetricObjectPropert
     }
 }
 
-impl From<&BoxWrap<SymmetricObjectProperty>> for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl From<&BoxWrap<SymmetricObjectProperty>>
+    for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<SymmetricObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for BoxWrap<SymmetricObjectProperty> {
+impl From<&Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<SymmetricObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<SymmetricObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<SymmetricObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<SymmetricObjectProperty>> for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl From<BoxWrap<SymmetricObjectProperty>>
+    for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<SymmetricObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for BoxWrap<SymmetricObjectProperty> {
+impl From<Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<SymmetricObjectProperty>
+{
     fn from(value: Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<SymmetricObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<SymmetricObjectProperty>> for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl From<VecWrap<SymmetricObjectProperty>>
+    for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<SymmetricObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for VecWrap<SymmetricObjectProperty> {
+impl From<Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for VecWrap<SymmetricObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<SymmetricObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<SymmetricObjectProperty>> for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl From<&VecWrap<SymmetricObjectProperty>>
+    for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<SymmetricObjectProperty>) -> Self {
         value
             .0
@@ -12570,48 +13341,66 @@ impl From<&VecWrap<SymmetricObjectProperty>> for Vec<horned_owl::model::Symmetri
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for VecWrap<SymmetricObjectProperty> {
+impl From<&Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for VecWrap<SymmetricObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(SymmetricObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<SymmetricObjectProperty>> for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<SymmetricObjectProperty>>
+    for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<SymmetricObjectProperty>) -> Self {
         Box::<horned_owl::model::SymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for BoxWrap<SymmetricObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<SymmetricObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<SymmetricObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<SymmetricObjectProperty>> for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<SymmetricObjectProperty>>
+    for Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<SymmetricObjectProperty>) -> Self {
         Box::<horned_owl::model::SymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for BoxWrap<SymmetricObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<SymmetricObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<SymmetricObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<SymmetricObjectProperty>> for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<SymmetricObjectProperty>>
+    for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<SymmetricObjectProperty>) -> Self {
         Vec::<horned_owl::model::SymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for VecWrap<SymmetricObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for VecWrap<SymmetricObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         VecWrap::<SymmetricObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<SymmetricObjectProperty>> for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<SymmetricObjectProperty>>
+    for Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<SymmetricObjectProperty>) -> Self {
         Vec::<horned_owl::model::SymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>> for VecWrap<SymmetricObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>>
+    for VecWrap<SymmetricObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>) -> Self {
         VecWrap::<SymmetricObjectProperty>::from(value)
     }
@@ -12621,26 +13410,24 @@ impl FromCompatible<&Vec<horned_owl::model::SymmetricObjectProperty<ArcStr>>> fo
     "\n\n",
     doc!(AsymmetricObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct AsymmetricObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct AsymmetricObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl AsymmetricObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        AsymmetricObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        AsymmetricObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -12653,9 +13440,10 @@ impl AsymmetricObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::AsymmetricObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::AsymmetricObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -12684,43 +13472,44 @@ impl AsymmetricObjectProperty {
 
 impl From<&horned_owl::model::AsymmetricObjectProperty<ArcStr>> for AsymmetricObjectProperty {
     fn from(value: &horned_owl::model::AsymmetricObjectProperty<ArcStr>) -> Self {
-
-        AsymmetricObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        AsymmetricObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0))
     }
 }
 
 impl From<&AsymmetricObjectProperty> for horned_owl::model::AsymmetricObjectProperty<ArcStr> {
     fn from(value: &AsymmetricObjectProperty) -> Self {
-        horned_owl::model::AsymmetricObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::AsymmetricObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for AsymmetricObjectProperty ****************/
-impl FromCompatible<horned_owl::model::AsymmetricObjectProperty<ArcStr>> for AsymmetricObjectProperty {
+impl FromCompatible<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+    for AsymmetricObjectProperty
+{
     fn from_c(value: horned_owl::model::AsymmetricObjectProperty<ArcStr>) -> Self {
         AsymmetricObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::AsymmetricObjectProperty<ArcStr>> for AsymmetricObjectProperty {
+impl FromCompatible<&horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+    for AsymmetricObjectProperty
+{
     fn from_c(value: &horned_owl::model::AsymmetricObjectProperty<ArcStr>) -> Self {
         AsymmetricObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<AsymmetricObjectProperty> for horned_owl::model::AsymmetricObjectProperty<ArcStr> {
+impl FromCompatible<AsymmetricObjectProperty>
+    for horned_owl::model::AsymmetricObjectProperty<ArcStr>
+{
     fn from_c(value: AsymmetricObjectProperty) -> Self {
         horned_owl::model::AsymmetricObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&AsymmetricObjectProperty> for horned_owl::model::AsymmetricObjectProperty<ArcStr> {
+impl FromCompatible<&AsymmetricObjectProperty>
+    for horned_owl::model::AsymmetricObjectProperty<ArcStr>
+{
     fn from_c(value: &AsymmetricObjectProperty) -> Self {
         horned_owl::model::AsymmetricObjectProperty::<ArcStr>::from(value)
     }
@@ -12738,43 +13527,59 @@ impl From<AsymmetricObjectProperty> for horned_owl::model::AsymmetricObjectPrope
     }
 }
 
-impl From<&BoxWrap<AsymmetricObjectProperty>> for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl From<&BoxWrap<AsymmetricObjectProperty>>
+    for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<AsymmetricObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for BoxWrap<AsymmetricObjectProperty> {
+impl From<&Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<AsymmetricObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<AsymmetricObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<AsymmetricObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<AsymmetricObjectProperty>> for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl From<BoxWrap<AsymmetricObjectProperty>>
+    for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<AsymmetricObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for BoxWrap<AsymmetricObjectProperty> {
+impl From<Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<AsymmetricObjectProperty>
+{
     fn from(value: Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<AsymmetricObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<AsymmetricObjectProperty>> for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl From<VecWrap<AsymmetricObjectProperty>>
+    for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<AsymmetricObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for VecWrap<AsymmetricObjectProperty> {
+impl From<Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for VecWrap<AsymmetricObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<AsymmetricObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<AsymmetricObjectProperty>> for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl From<&VecWrap<AsymmetricObjectProperty>>
+    for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<AsymmetricObjectProperty>) -> Self {
         value
             .0
@@ -12783,48 +13588,66 @@ impl From<&VecWrap<AsymmetricObjectProperty>> for Vec<horned_owl::model::Asymmet
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for VecWrap<AsymmetricObjectProperty> {
+impl From<&Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for VecWrap<AsymmetricObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(AsymmetricObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<AsymmetricObjectProperty>> for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<AsymmetricObjectProperty>>
+    for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AsymmetricObjectProperty>) -> Self {
         Box::<horned_owl::model::AsymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for BoxWrap<AsymmetricObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<AsymmetricObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<AsymmetricObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AsymmetricObjectProperty>> for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<AsymmetricObjectProperty>>
+    for Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<AsymmetricObjectProperty>) -> Self {
         Box::<horned_owl::model::AsymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for BoxWrap<AsymmetricObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for BoxWrap<AsymmetricObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<AsymmetricObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AsymmetricObjectProperty>> for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<AsymmetricObjectProperty>>
+    for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<AsymmetricObjectProperty>) -> Self {
         Vec::<horned_owl::model::AsymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for VecWrap<AsymmetricObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for VecWrap<AsymmetricObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         VecWrap::<AsymmetricObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AsymmetricObjectProperty>> for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<AsymmetricObjectProperty>>
+    for Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<AsymmetricObjectProperty>) -> Self {
         Vec::<horned_owl::model::AsymmetricObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> for VecWrap<AsymmetricObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>>
+    for VecWrap<AsymmetricObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>) -> Self {
         VecWrap::<AsymmetricObjectProperty>::from(value)
     }
@@ -12834,26 +13657,24 @@ impl FromCompatible<&Vec<horned_owl::model::AsymmetricObjectProperty<ArcStr>>> f
     "\n\n",
     doc!(TransitiveObjectProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct TransitiveObjectProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct TransitiveObjectProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub ObjectPropertyExpression,
 );
 
 #[pymethods]
 impl TransitiveObjectProperty {
     #[new]
-    fn new(first: ObjectPropertyExpression,) -> Self {
-        TransitiveObjectProperty (first,)
+    fn new(first: ObjectPropertyExpression) -> Self {
+        TransitiveObjectProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -12866,9 +13687,10 @@ impl TransitiveObjectProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::TransitiveObjectProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::TransitiveObjectProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -12897,43 +13719,44 @@ impl TransitiveObjectProperty {
 
 impl From<&horned_owl::model::TransitiveObjectProperty<ArcStr>> for TransitiveObjectProperty {
     fn from(value: &horned_owl::model::TransitiveObjectProperty<ArcStr>) -> Self {
-
-        TransitiveObjectProperty (
-    IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0),
-        )
+        TransitiveObjectProperty(IntoCompatible::<ObjectPropertyExpression>::into_c(&value.0))
     }
 }
 
 impl From<&TransitiveObjectProperty> for horned_owl::model::TransitiveObjectProperty<ArcStr> {
     fn from(value: &TransitiveObjectProperty) -> Self {
-        horned_owl::model::TransitiveObjectProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::TransitiveObjectProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for TransitiveObjectProperty ****************/
-impl FromCompatible<horned_owl::model::TransitiveObjectProperty<ArcStr>> for TransitiveObjectProperty {
+impl FromCompatible<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+    for TransitiveObjectProperty
+{
     fn from_c(value: horned_owl::model::TransitiveObjectProperty<ArcStr>) -> Self {
         TransitiveObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::TransitiveObjectProperty<ArcStr>> for TransitiveObjectProperty {
+impl FromCompatible<&horned_owl::model::TransitiveObjectProperty<ArcStr>>
+    for TransitiveObjectProperty
+{
     fn from_c(value: &horned_owl::model::TransitiveObjectProperty<ArcStr>) -> Self {
         TransitiveObjectProperty::from(value)
     }
 }
 
-impl FromCompatible<TransitiveObjectProperty> for horned_owl::model::TransitiveObjectProperty<ArcStr> {
+impl FromCompatible<TransitiveObjectProperty>
+    for horned_owl::model::TransitiveObjectProperty<ArcStr>
+{
     fn from_c(value: TransitiveObjectProperty) -> Self {
         horned_owl::model::TransitiveObjectProperty::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&TransitiveObjectProperty> for horned_owl::model::TransitiveObjectProperty<ArcStr> {
+impl FromCompatible<&TransitiveObjectProperty>
+    for horned_owl::model::TransitiveObjectProperty<ArcStr>
+{
     fn from_c(value: &TransitiveObjectProperty) -> Self {
         horned_owl::model::TransitiveObjectProperty::<ArcStr>::from(value)
     }
@@ -12951,43 +13774,59 @@ impl From<TransitiveObjectProperty> for horned_owl::model::TransitiveObjectPrope
     }
 }
 
-impl From<&BoxWrap<TransitiveObjectProperty>> for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl From<&BoxWrap<TransitiveObjectProperty>>
+    for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<TransitiveObjectProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for BoxWrap<TransitiveObjectProperty> {
+impl From<&Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for BoxWrap<TransitiveObjectProperty>
+{
     fn from(value: &Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<TransitiveObjectProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<TransitiveObjectProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<TransitiveObjectProperty>> for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl From<BoxWrap<TransitiveObjectProperty>>
+    for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from(value: BoxWrap<TransitiveObjectProperty>) -> Self {
         Into::<Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for BoxWrap<TransitiveObjectProperty> {
+impl From<Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for BoxWrap<TransitiveObjectProperty>
+{
     fn from(value: Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<TransitiveObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<TransitiveObjectProperty>> for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl From<VecWrap<TransitiveObjectProperty>>
+    for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from(value: VecWrap<TransitiveObjectProperty>) -> Self {
         Into::<Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for VecWrap<TransitiveObjectProperty> {
+impl From<Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for VecWrap<TransitiveObjectProperty>
+{
     fn from(value: Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         Into::<VecWrap<TransitiveObjectProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<TransitiveObjectProperty>> for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl From<&VecWrap<TransitiveObjectProperty>>
+    for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from(value: &VecWrap<TransitiveObjectProperty>) -> Self {
         value
             .0
@@ -12996,48 +13835,66 @@ impl From<&VecWrap<TransitiveObjectProperty>> for Vec<horned_owl::model::Transit
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for VecWrap<TransitiveObjectProperty> {
+impl From<&Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for VecWrap<TransitiveObjectProperty>
+{
     fn from(value: &Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(TransitiveObjectProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<TransitiveObjectProperty>> for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<TransitiveObjectProperty>>
+    for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<TransitiveObjectProperty>) -> Self {
         Box::<horned_owl::model::TransitiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for BoxWrap<TransitiveObjectProperty> {
+impl FromCompatible<&Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for BoxWrap<TransitiveObjectProperty>
+{
     fn from_c(value: &Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<TransitiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<TransitiveObjectProperty>> for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<TransitiveObjectProperty>>
+    for Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<TransitiveObjectProperty>) -> Self {
         Box::<horned_owl::model::TransitiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for BoxWrap<TransitiveObjectProperty> {
+impl FromCompatible<Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for BoxWrap<TransitiveObjectProperty>
+{
     fn from_c(value: Box<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         BoxWrap::<TransitiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<TransitiveObjectProperty>> for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl FromCompatible<VecWrap<TransitiveObjectProperty>>
+    for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<TransitiveObjectProperty>) -> Self {
         Vec::<horned_owl::model::TransitiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for VecWrap<TransitiveObjectProperty> {
+impl FromCompatible<Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for VecWrap<TransitiveObjectProperty>
+{
     fn from_c(value: Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         VecWrap::<TransitiveObjectProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<TransitiveObjectProperty>> for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<TransitiveObjectProperty>>
+    for Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<TransitiveObjectProperty>) -> Self {
         Vec::<horned_owl::model::TransitiveObjectProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>> for VecWrap<TransitiveObjectProperty> {
+impl FromCompatible<&Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>>
+    for VecWrap<TransitiveObjectProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>) -> Self {
         VecWrap::<TransitiveObjectProperty>::from(value)
     }
@@ -13046,41 +13903,38 @@ impl FromCompatible<&Vec<horned_owl::model::TransitiveObjectProperty<ArcStr>>> f
     "\n\n",
     doc!(SubDataPropertyOf)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubDataPropertyOf {
-        #[doc="sub: DataProperty"]
-        #[pyo3(get,set)]
-        pub sub: DataProperty,
-    
-        #[doc="sup: DataProperty"]
-        #[pyo3(get,set)]
-        pub sup: DataProperty,
-    }
+    #[doc = "sub: DataProperty"]
+    #[pyo3(get, set)]
+    pub sub: DataProperty,
+
+    #[doc = "sup: DataProperty"]
+    #[pyo3(get, set)]
+    pub sup: DataProperty,
+}
 
 #[pymethods]
 impl SubDataPropertyOf {
     #[new]
-    fn new(sub: DataProperty,sup: DataProperty,) -> Self {
-        SubDataPropertyOf {
-                sub,
-                sup,
-        }
+    fn new(sub: DataProperty, sup: DataProperty) -> Self {
+        SubDataPropertyOf { sub, sup }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "sub".to_string(),
-            "sup".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("sub".to_string(), "sup".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "sub" => self.sub.clone().into_pyobject(py).map(Bound::into_any),
             "sup" => self.sup.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -13089,12 +13943,15 @@ impl SubDataPropertyOf {
             "sub" => {
                 self.sub = value.extract()?;
                 Ok(())
-            },
+            }
             "sup" => {
                 self.sup = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -13108,9 +13965,10 @@ impl SubDataPropertyOf {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::SubDataPropertyOf<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::SubDataPropertyOf<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -13146,7 +14004,6 @@ impl From<&horned_owl::model::SubDataPropertyOf<ArcStr>> for SubDataPropertyOf {
     }
 }
 
-
 impl From<&SubDataPropertyOf> for horned_owl::model::SubDataPropertyOf<ArcStr> {
     fn from(value: &SubDataPropertyOf) -> Self {
         horned_owl::model::SubDataPropertyOf::<ArcStr> {
@@ -13155,8 +14012,6 @@ impl From<&SubDataPropertyOf> for horned_owl::model::SubDataPropertyOf<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for SubDataPropertyOf ****************/
 impl FromCompatible<horned_owl::model::SubDataPropertyOf<ArcStr>> for SubDataPropertyOf {
@@ -13246,42 +14101,58 @@ impl From<&Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>> for VecWrap<SubDat
     }
 }
 
-impl FromCompatible<&BoxWrap<SubDataPropertyOf>> for Box<horned_owl::model::SubDataPropertyOf<ArcStr>> {
+impl FromCompatible<&BoxWrap<SubDataPropertyOf>>
+    for Box<horned_owl::model::SubDataPropertyOf<ArcStr>>
+{
     fn from_c(value: &BoxWrap<SubDataPropertyOf>) -> Self {
         Box::<horned_owl::model::SubDataPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::SubDataPropertyOf<ArcStr>>> for BoxWrap<SubDataPropertyOf> {
+impl FromCompatible<&Box<horned_owl::model::SubDataPropertyOf<ArcStr>>>
+    for BoxWrap<SubDataPropertyOf>
+{
     fn from_c(value: &Box<horned_owl::model::SubDataPropertyOf<ArcStr>>) -> Self {
         BoxWrap::<SubDataPropertyOf>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<SubDataPropertyOf>> for Box<horned_owl::model::SubDataPropertyOf<ArcStr>> {
+impl FromCompatible<BoxWrap<SubDataPropertyOf>>
+    for Box<horned_owl::model::SubDataPropertyOf<ArcStr>>
+{
     fn from_c(value: BoxWrap<SubDataPropertyOf>) -> Self {
         Box::<horned_owl::model::SubDataPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::SubDataPropertyOf<ArcStr>>> for BoxWrap<SubDataPropertyOf> {
+impl FromCompatible<Box<horned_owl::model::SubDataPropertyOf<ArcStr>>>
+    for BoxWrap<SubDataPropertyOf>
+{
     fn from_c(value: Box<horned_owl::model::SubDataPropertyOf<ArcStr>>) -> Self {
         BoxWrap::<SubDataPropertyOf>::from(value)
     }
 }
-impl FromCompatible<VecWrap<SubDataPropertyOf>> for Vec<horned_owl::model::SubDataPropertyOf<ArcStr>> {
+impl FromCompatible<VecWrap<SubDataPropertyOf>>
+    for Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>
+{
     fn from_c(value: VecWrap<SubDataPropertyOf>) -> Self {
         Vec::<horned_owl::model::SubDataPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>> for VecWrap<SubDataPropertyOf> {
+impl FromCompatible<Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>>
+    for VecWrap<SubDataPropertyOf>
+{
     fn from_c(value: Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>) -> Self {
         VecWrap::<SubDataPropertyOf>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<SubDataPropertyOf>> for Vec<horned_owl::model::SubDataPropertyOf<ArcStr>> {
+impl FromCompatible<&VecWrap<SubDataPropertyOf>>
+    for Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>
+{
     fn from_c(value: &VecWrap<SubDataPropertyOf>) -> Self {
         Vec::<horned_owl::model::SubDataPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>> for VecWrap<SubDataPropertyOf> {
+impl FromCompatible<&Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>>
+    for VecWrap<SubDataPropertyOf>
+{
     fn from_c(value: &Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>) -> Self {
         VecWrap::<SubDataPropertyOf>::from(value)
     }
@@ -13291,26 +14162,24 @@ impl FromCompatible<&Vec<horned_owl::model::SubDataPropertyOf<ArcStr>>> for VecW
     "\n\n",
     doc!(EquivalentDataProperties)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct EquivalentDataProperties (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct EquivalentDataProperties(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<DataProperty>,
 );
 
 #[pymethods]
 impl EquivalentDataProperties {
     #[new]
-    fn new(first: VecWrap<DataProperty>,) -> Self {
-        EquivalentDataProperties (first,)
+    fn new(first: VecWrap<DataProperty>) -> Self {
+        EquivalentDataProperties(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -13323,9 +14192,10 @@ impl EquivalentDataProperties {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::EquivalentDataProperties<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::EquivalentDataProperties<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -13354,43 +14224,44 @@ impl EquivalentDataProperties {
 
 impl From<&horned_owl::model::EquivalentDataProperties<ArcStr>> for EquivalentDataProperties {
     fn from(value: &horned_owl::model::EquivalentDataProperties<ArcStr>) -> Self {
-
-        EquivalentDataProperties (
-    IntoCompatible::<VecWrap<DataProperty>>::into_c(&value.0),
-        )
+        EquivalentDataProperties(IntoCompatible::<VecWrap<DataProperty>>::into_c(&value.0))
     }
 }
 
 impl From<&EquivalentDataProperties> for horned_owl::model::EquivalentDataProperties<ArcStr> {
     fn from(value: &EquivalentDataProperties) -> Self {
-        horned_owl::model::EquivalentDataProperties::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::EquivalentDataProperties::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
 
-
-
 /**************** Base implementations for EquivalentDataProperties ****************/
-impl FromCompatible<horned_owl::model::EquivalentDataProperties<ArcStr>> for EquivalentDataProperties {
+impl FromCompatible<horned_owl::model::EquivalentDataProperties<ArcStr>>
+    for EquivalentDataProperties
+{
     fn from_c(value: horned_owl::model::EquivalentDataProperties<ArcStr>) -> Self {
         EquivalentDataProperties::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::EquivalentDataProperties<ArcStr>> for EquivalentDataProperties {
+impl FromCompatible<&horned_owl::model::EquivalentDataProperties<ArcStr>>
+    for EquivalentDataProperties
+{
     fn from_c(value: &horned_owl::model::EquivalentDataProperties<ArcStr>) -> Self {
         EquivalentDataProperties::from(value)
     }
 }
 
-impl FromCompatible<EquivalentDataProperties> for horned_owl::model::EquivalentDataProperties<ArcStr> {
+impl FromCompatible<EquivalentDataProperties>
+    for horned_owl::model::EquivalentDataProperties<ArcStr>
+{
     fn from_c(value: EquivalentDataProperties) -> Self {
         horned_owl::model::EquivalentDataProperties::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&EquivalentDataProperties> for horned_owl::model::EquivalentDataProperties<ArcStr> {
+impl FromCompatible<&EquivalentDataProperties>
+    for horned_owl::model::EquivalentDataProperties<ArcStr>
+{
     fn from_c(value: &EquivalentDataProperties) -> Self {
         horned_owl::model::EquivalentDataProperties::<ArcStr>::from(value)
     }
@@ -13408,43 +14279,59 @@ impl From<EquivalentDataProperties> for horned_owl::model::EquivalentDataPropert
     }
 }
 
-impl From<&BoxWrap<EquivalentDataProperties>> for Box<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl From<&BoxWrap<EquivalentDataProperties>>
+    for Box<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from(value: &BoxWrap<EquivalentDataProperties>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::EquivalentDataProperties<ArcStr>>> for BoxWrap<EquivalentDataProperties> {
+impl From<&Box<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for BoxWrap<EquivalentDataProperties>
+{
     fn from(value: &Box<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<EquivalentDataProperties>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<EquivalentDataProperties>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<EquivalentDataProperties>> for Box<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl From<BoxWrap<EquivalentDataProperties>>
+    for Box<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from(value: BoxWrap<EquivalentDataProperties>) -> Self {
         Into::<Box<horned_owl::model::EquivalentDataProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::EquivalentDataProperties<ArcStr>>> for BoxWrap<EquivalentDataProperties> {
+impl From<Box<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for BoxWrap<EquivalentDataProperties>
+{
     fn from(value: Box<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         Into::<BoxWrap<EquivalentDataProperties>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<EquivalentDataProperties>> for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl From<VecWrap<EquivalentDataProperties>>
+    for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from(value: VecWrap<EquivalentDataProperties>) -> Self {
         Into::<Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>> for VecWrap<EquivalentDataProperties> {
+impl From<Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for VecWrap<EquivalentDataProperties>
+{
     fn from(value: Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         Into::<VecWrap<EquivalentDataProperties>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<EquivalentDataProperties>> for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl From<&VecWrap<EquivalentDataProperties>>
+    for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from(value: &VecWrap<EquivalentDataProperties>) -> Self {
         value
             .0
@@ -13453,48 +14340,66 @@ impl From<&VecWrap<EquivalentDataProperties>> for Vec<horned_owl::model::Equival
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>> for VecWrap<EquivalentDataProperties> {
+impl From<&Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for VecWrap<EquivalentDataProperties>
+{
     fn from(value: &Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         VecWrap(value.iter().map(EquivalentDataProperties::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<EquivalentDataProperties>> for Box<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl FromCompatible<&BoxWrap<EquivalentDataProperties>>
+    for Box<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from_c(value: &BoxWrap<EquivalentDataProperties>) -> Self {
         Box::<horned_owl::model::EquivalentDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::EquivalentDataProperties<ArcStr>>> for BoxWrap<EquivalentDataProperties> {
+impl FromCompatible<&Box<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for BoxWrap<EquivalentDataProperties>
+{
     fn from_c(value: &Box<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         BoxWrap::<EquivalentDataProperties>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<EquivalentDataProperties>> for Box<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl FromCompatible<BoxWrap<EquivalentDataProperties>>
+    for Box<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from_c(value: BoxWrap<EquivalentDataProperties>) -> Self {
         Box::<horned_owl::model::EquivalentDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::EquivalentDataProperties<ArcStr>>> for BoxWrap<EquivalentDataProperties> {
+impl FromCompatible<Box<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for BoxWrap<EquivalentDataProperties>
+{
     fn from_c(value: Box<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         BoxWrap::<EquivalentDataProperties>::from(value)
     }
 }
-impl FromCompatible<VecWrap<EquivalentDataProperties>> for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl FromCompatible<VecWrap<EquivalentDataProperties>>
+    for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from_c(value: VecWrap<EquivalentDataProperties>) -> Self {
         Vec::<horned_owl::model::EquivalentDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>> for VecWrap<EquivalentDataProperties> {
+impl FromCompatible<Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for VecWrap<EquivalentDataProperties>
+{
     fn from_c(value: Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         VecWrap::<EquivalentDataProperties>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<EquivalentDataProperties>> for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>> {
+impl FromCompatible<&VecWrap<EquivalentDataProperties>>
+    for Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>
+{
     fn from_c(value: &VecWrap<EquivalentDataProperties>) -> Self {
         Vec::<horned_owl::model::EquivalentDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>> for VecWrap<EquivalentDataProperties> {
+impl FromCompatible<&Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>>
+    for VecWrap<EquivalentDataProperties>
+{
     fn from_c(value: &Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>) -> Self {
         VecWrap::<EquivalentDataProperties>::from(value)
     }
@@ -13504,26 +14409,24 @@ impl FromCompatible<&Vec<horned_owl::model::EquivalentDataProperties<ArcStr>>> f
     "\n\n",
     doc!(DisjointDataProperties)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DisjointDataProperties (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DisjointDataProperties(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<DataProperty>,
 );
 
 #[pymethods]
 impl DisjointDataProperties {
     #[new]
-    fn new(first: VecWrap<DataProperty>,) -> Self {
-        DisjointDataProperties (first,)
+    fn new(first: VecWrap<DataProperty>) -> Self {
+        DisjointDataProperties(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -13536,9 +14439,10 @@ impl DisjointDataProperties {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DisjointDataProperties<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DisjointDataProperties<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -13567,22 +14471,15 @@ impl DisjointDataProperties {
 
 impl From<&horned_owl::model::DisjointDataProperties<ArcStr>> for DisjointDataProperties {
     fn from(value: &horned_owl::model::DisjointDataProperties<ArcStr>) -> Self {
-
-        DisjointDataProperties (
-    IntoCompatible::<VecWrap<DataProperty>>::into_c(&value.0),
-        )
+        DisjointDataProperties(IntoCompatible::<VecWrap<DataProperty>>::into_c(&value.0))
     }
 }
 
 impl From<&DisjointDataProperties> for horned_owl::model::DisjointDataProperties<ArcStr> {
     fn from(value: &DisjointDataProperties) -> Self {
-        horned_owl::model::DisjointDataProperties::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DisjointDataProperties::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DisjointDataProperties ****************/
 impl FromCompatible<horned_owl::model::DisjointDataProperties<ArcStr>> for DisjointDataProperties {
@@ -13621,43 +14518,59 @@ impl From<DisjointDataProperties> for horned_owl::model::DisjointDataProperties<
     }
 }
 
-impl From<&BoxWrap<DisjointDataProperties>> for Box<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl From<&BoxWrap<DisjointDataProperties>>
+    for Box<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from(value: &BoxWrap<DisjointDataProperties>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::DisjointDataProperties<ArcStr>>> for BoxWrap<DisjointDataProperties> {
+impl From<&Box<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for BoxWrap<DisjointDataProperties>
+{
     fn from(value: &Box<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<DisjointDataProperties>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<DisjointDataProperties>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<DisjointDataProperties>> for Box<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl From<BoxWrap<DisjointDataProperties>>
+    for Box<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from(value: BoxWrap<DisjointDataProperties>) -> Self {
         Into::<Box<horned_owl::model::DisjointDataProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::DisjointDataProperties<ArcStr>>> for BoxWrap<DisjointDataProperties> {
+impl From<Box<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for BoxWrap<DisjointDataProperties>
+{
     fn from(value: Box<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         Into::<BoxWrap<DisjointDataProperties>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<DisjointDataProperties>> for Vec<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl From<VecWrap<DisjointDataProperties>>
+    for Vec<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from(value: VecWrap<DisjointDataProperties>) -> Self {
         Into::<Vec<horned_owl::model::DisjointDataProperties<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::DisjointDataProperties<ArcStr>>> for VecWrap<DisjointDataProperties> {
+impl From<Vec<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for VecWrap<DisjointDataProperties>
+{
     fn from(value: Vec<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         Into::<VecWrap<DisjointDataProperties>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<DisjointDataProperties>> for Vec<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl From<&VecWrap<DisjointDataProperties>>
+    for Vec<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from(value: &VecWrap<DisjointDataProperties>) -> Self {
         value
             .0
@@ -13666,48 +14579,66 @@ impl From<&VecWrap<DisjointDataProperties>> for Vec<horned_owl::model::DisjointD
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::DisjointDataProperties<ArcStr>>> for VecWrap<DisjointDataProperties> {
+impl From<&Vec<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for VecWrap<DisjointDataProperties>
+{
     fn from(value: &Vec<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         VecWrap(value.iter().map(DisjointDataProperties::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<DisjointDataProperties>> for Box<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl FromCompatible<&BoxWrap<DisjointDataProperties>>
+    for Box<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DisjointDataProperties>) -> Self {
         Box::<horned_owl::model::DisjointDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DisjointDataProperties<ArcStr>>> for BoxWrap<DisjointDataProperties> {
+impl FromCompatible<&Box<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for BoxWrap<DisjointDataProperties>
+{
     fn from_c(value: &Box<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         BoxWrap::<DisjointDataProperties>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DisjointDataProperties>> for Box<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl FromCompatible<BoxWrap<DisjointDataProperties>>
+    for Box<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from_c(value: BoxWrap<DisjointDataProperties>) -> Self {
         Box::<horned_owl::model::DisjointDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DisjointDataProperties<ArcStr>>> for BoxWrap<DisjointDataProperties> {
+impl FromCompatible<Box<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for BoxWrap<DisjointDataProperties>
+{
     fn from_c(value: Box<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         BoxWrap::<DisjointDataProperties>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DisjointDataProperties>> for Vec<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl FromCompatible<VecWrap<DisjointDataProperties>>
+    for Vec<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from_c(value: VecWrap<DisjointDataProperties>) -> Self {
         Vec::<horned_owl::model::DisjointDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DisjointDataProperties<ArcStr>>> for VecWrap<DisjointDataProperties> {
+impl FromCompatible<Vec<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for VecWrap<DisjointDataProperties>
+{
     fn from_c(value: Vec<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         VecWrap::<DisjointDataProperties>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DisjointDataProperties>> for Vec<horned_owl::model::DisjointDataProperties<ArcStr>> {
+impl FromCompatible<&VecWrap<DisjointDataProperties>>
+    for Vec<horned_owl::model::DisjointDataProperties<ArcStr>>
+{
     fn from_c(value: &VecWrap<DisjointDataProperties>) -> Self {
         Vec::<horned_owl::model::DisjointDataProperties<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DisjointDataProperties<ArcStr>>> for VecWrap<DisjointDataProperties> {
+impl FromCompatible<&Vec<horned_owl::model::DisjointDataProperties<ArcStr>>>
+    for VecWrap<DisjointDataProperties>
+{
     fn from_c(value: &Vec<horned_owl::model::DisjointDataProperties<ArcStr>>) -> Self {
         VecWrap::<DisjointDataProperties>::from(value)
     }
@@ -13716,41 +14647,38 @@ impl FromCompatible<&Vec<horned_owl::model::DisjointDataProperties<ArcStr>>> for
     "\n\n",
     doc!(DataPropertyDomain)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DataPropertyDomain {
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-    
-        #[doc="ce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub ce: ClassExpression,
-    }
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+
+    #[doc = "ce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub ce: ClassExpression,
+}
 
 #[pymethods]
 impl DataPropertyDomain {
     #[new]
-    fn new(dp: DataProperty,ce: ClassExpression,) -> Self {
-        DataPropertyDomain {
-                dp,
-                ce,
-        }
+    fn new(dp: DataProperty, ce: ClassExpression) -> Self {
+        DataPropertyDomain { dp, ce }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "dp".to_string(),
-            "ce".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("dp".to_string(), "ce".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any),
             "ce" => self.ce.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -13759,12 +14687,15 @@ impl DataPropertyDomain {
             "dp" => {
                 self.dp = value.extract()?;
                 Ok(())
-            },
+            }
             "ce" => {
                 self.ce = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -13778,9 +14709,10 @@ impl DataPropertyDomain {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DataPropertyDomain<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DataPropertyDomain<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -13816,7 +14748,6 @@ impl From<&horned_owl::model::DataPropertyDomain<ArcStr>> for DataPropertyDomain
     }
 }
 
-
 impl From<&DataPropertyDomain> for horned_owl::model::DataPropertyDomain<ArcStr> {
     fn from(value: &DataPropertyDomain) -> Self {
         horned_owl::model::DataPropertyDomain::<ArcStr> {
@@ -13825,8 +14756,6 @@ impl From<&DataPropertyDomain> for horned_owl::model::DataPropertyDomain<ArcStr>
         }
     }
 }
-
-
 
 /**************** Base implementations for DataPropertyDomain ****************/
 impl FromCompatible<horned_owl::model::DataPropertyDomain<ArcStr>> for DataPropertyDomain {
@@ -13916,42 +14845,58 @@ impl From<&Vec<horned_owl::model::DataPropertyDomain<ArcStr>>> for VecWrap<DataP
     }
 }
 
-impl FromCompatible<&BoxWrap<DataPropertyDomain>> for Box<horned_owl::model::DataPropertyDomain<ArcStr>> {
+impl FromCompatible<&BoxWrap<DataPropertyDomain>>
+    for Box<horned_owl::model::DataPropertyDomain<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DataPropertyDomain>) -> Self {
         Box::<horned_owl::model::DataPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DataPropertyDomain<ArcStr>>> for BoxWrap<DataPropertyDomain> {
+impl FromCompatible<&Box<horned_owl::model::DataPropertyDomain<ArcStr>>>
+    for BoxWrap<DataPropertyDomain>
+{
     fn from_c(value: &Box<horned_owl::model::DataPropertyDomain<ArcStr>>) -> Self {
         BoxWrap::<DataPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DataPropertyDomain>> for Box<horned_owl::model::DataPropertyDomain<ArcStr>> {
+impl FromCompatible<BoxWrap<DataPropertyDomain>>
+    for Box<horned_owl::model::DataPropertyDomain<ArcStr>>
+{
     fn from_c(value: BoxWrap<DataPropertyDomain>) -> Self {
         Box::<horned_owl::model::DataPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DataPropertyDomain<ArcStr>>> for BoxWrap<DataPropertyDomain> {
+impl FromCompatible<Box<horned_owl::model::DataPropertyDomain<ArcStr>>>
+    for BoxWrap<DataPropertyDomain>
+{
     fn from_c(value: Box<horned_owl::model::DataPropertyDomain<ArcStr>>) -> Self {
         BoxWrap::<DataPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DataPropertyDomain>> for Vec<horned_owl::model::DataPropertyDomain<ArcStr>> {
+impl FromCompatible<VecWrap<DataPropertyDomain>>
+    for Vec<horned_owl::model::DataPropertyDomain<ArcStr>>
+{
     fn from_c(value: VecWrap<DataPropertyDomain>) -> Self {
         Vec::<horned_owl::model::DataPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DataPropertyDomain<ArcStr>>> for VecWrap<DataPropertyDomain> {
+impl FromCompatible<Vec<horned_owl::model::DataPropertyDomain<ArcStr>>>
+    for VecWrap<DataPropertyDomain>
+{
     fn from_c(value: Vec<horned_owl::model::DataPropertyDomain<ArcStr>>) -> Self {
         VecWrap::<DataPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DataPropertyDomain>> for Vec<horned_owl::model::DataPropertyDomain<ArcStr>> {
+impl FromCompatible<&VecWrap<DataPropertyDomain>>
+    for Vec<horned_owl::model::DataPropertyDomain<ArcStr>>
+{
     fn from_c(value: &VecWrap<DataPropertyDomain>) -> Self {
         Vec::<horned_owl::model::DataPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DataPropertyDomain<ArcStr>>> for VecWrap<DataPropertyDomain> {
+impl FromCompatible<&Vec<horned_owl::model::DataPropertyDomain<ArcStr>>>
+    for VecWrap<DataPropertyDomain>
+{
     fn from_c(value: &Vec<horned_owl::model::DataPropertyDomain<ArcStr>>) -> Self {
         VecWrap::<DataPropertyDomain>::from(value)
     }
@@ -13960,41 +14905,38 @@ impl FromCompatible<&Vec<horned_owl::model::DataPropertyDomain<ArcStr>>> for Vec
     "\n\n",
     doc!(DataPropertyRange)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DataPropertyRange {
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-    
-        #[doc="dr: DataRange"]
-        #[pyo3(get,set)]
-        pub dr: DataRange,
-    }
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+
+    #[doc = "dr: DataRange"]
+    #[pyo3(get, set)]
+    pub dr: DataRange,
+}
 
 #[pymethods]
 impl DataPropertyRange {
     #[new]
-    fn new(dp: DataProperty,dr: DataRange,) -> Self {
-        DataPropertyRange {
-                dp,
-                dr,
-        }
+    fn new(dp: DataProperty, dr: DataRange) -> Self {
+        DataPropertyRange { dp, dr }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "dp".to_string(),
-            "dr".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("dp".to_string(), "dr".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any),
             "dr" => self.dr.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -14003,12 +14945,15 @@ impl DataPropertyRange {
             "dp" => {
                 self.dp = value.extract()?;
                 Ok(())
-            },
+            }
             "dr" => {
                 self.dr = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -14022,9 +14967,10 @@ impl DataPropertyRange {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DataPropertyRange<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DataPropertyRange<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -14060,7 +15006,6 @@ impl From<&horned_owl::model::DataPropertyRange<ArcStr>> for DataPropertyRange {
     }
 }
 
-
 impl From<&DataPropertyRange> for horned_owl::model::DataPropertyRange<ArcStr> {
     fn from(value: &DataPropertyRange) -> Self {
         horned_owl::model::DataPropertyRange::<ArcStr> {
@@ -14069,8 +15014,6 @@ impl From<&DataPropertyRange> for horned_owl::model::DataPropertyRange<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for DataPropertyRange ****************/
 impl FromCompatible<horned_owl::model::DataPropertyRange<ArcStr>> for DataPropertyRange {
@@ -14160,42 +15103,58 @@ impl From<&Vec<horned_owl::model::DataPropertyRange<ArcStr>>> for VecWrap<DataPr
     }
 }
 
-impl FromCompatible<&BoxWrap<DataPropertyRange>> for Box<horned_owl::model::DataPropertyRange<ArcStr>> {
+impl FromCompatible<&BoxWrap<DataPropertyRange>>
+    for Box<horned_owl::model::DataPropertyRange<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DataPropertyRange>) -> Self {
         Box::<horned_owl::model::DataPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DataPropertyRange<ArcStr>>> for BoxWrap<DataPropertyRange> {
+impl FromCompatible<&Box<horned_owl::model::DataPropertyRange<ArcStr>>>
+    for BoxWrap<DataPropertyRange>
+{
     fn from_c(value: &Box<horned_owl::model::DataPropertyRange<ArcStr>>) -> Self {
         BoxWrap::<DataPropertyRange>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DataPropertyRange>> for Box<horned_owl::model::DataPropertyRange<ArcStr>> {
+impl FromCompatible<BoxWrap<DataPropertyRange>>
+    for Box<horned_owl::model::DataPropertyRange<ArcStr>>
+{
     fn from_c(value: BoxWrap<DataPropertyRange>) -> Self {
         Box::<horned_owl::model::DataPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DataPropertyRange<ArcStr>>> for BoxWrap<DataPropertyRange> {
+impl FromCompatible<Box<horned_owl::model::DataPropertyRange<ArcStr>>>
+    for BoxWrap<DataPropertyRange>
+{
     fn from_c(value: Box<horned_owl::model::DataPropertyRange<ArcStr>>) -> Self {
         BoxWrap::<DataPropertyRange>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DataPropertyRange>> for Vec<horned_owl::model::DataPropertyRange<ArcStr>> {
+impl FromCompatible<VecWrap<DataPropertyRange>>
+    for Vec<horned_owl::model::DataPropertyRange<ArcStr>>
+{
     fn from_c(value: VecWrap<DataPropertyRange>) -> Self {
         Vec::<horned_owl::model::DataPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DataPropertyRange<ArcStr>>> for VecWrap<DataPropertyRange> {
+impl FromCompatible<Vec<horned_owl::model::DataPropertyRange<ArcStr>>>
+    for VecWrap<DataPropertyRange>
+{
     fn from_c(value: Vec<horned_owl::model::DataPropertyRange<ArcStr>>) -> Self {
         VecWrap::<DataPropertyRange>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DataPropertyRange>> for Vec<horned_owl::model::DataPropertyRange<ArcStr>> {
+impl FromCompatible<&VecWrap<DataPropertyRange>>
+    for Vec<horned_owl::model::DataPropertyRange<ArcStr>>
+{
     fn from_c(value: &VecWrap<DataPropertyRange>) -> Self {
         Vec::<horned_owl::model::DataPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DataPropertyRange<ArcStr>>> for VecWrap<DataPropertyRange> {
+impl FromCompatible<&Vec<horned_owl::model::DataPropertyRange<ArcStr>>>
+    for VecWrap<DataPropertyRange>
+{
     fn from_c(value: &Vec<horned_owl::model::DataPropertyRange<ArcStr>>) -> Self {
         VecWrap::<DataPropertyRange>::from(value)
     }
@@ -14205,26 +15164,24 @@ impl FromCompatible<&Vec<horned_owl::model::DataPropertyRange<ArcStr>>> for VecW
     "\n\n",
     doc!(FunctionalDataProperty)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct FunctionalDataProperty (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct FunctionalDataProperty(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub DataProperty,
 );
 
 #[pymethods]
 impl FunctionalDataProperty {
     #[new]
-    fn new(first: DataProperty,) -> Self {
-        FunctionalDataProperty (first,)
+    fn new(first: DataProperty) -> Self {
+        FunctionalDataProperty(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -14237,9 +15194,10 @@ impl FunctionalDataProperty {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::FunctionalDataProperty<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::FunctionalDataProperty<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -14268,22 +15226,15 @@ impl FunctionalDataProperty {
 
 impl From<&horned_owl::model::FunctionalDataProperty<ArcStr>> for FunctionalDataProperty {
     fn from(value: &horned_owl::model::FunctionalDataProperty<ArcStr>) -> Self {
-
-        FunctionalDataProperty (
-    IntoCompatible::<DataProperty>::into_c(&value.0),
-        )
+        FunctionalDataProperty(IntoCompatible::<DataProperty>::into_c(&value.0))
     }
 }
 
 impl From<&FunctionalDataProperty> for horned_owl::model::FunctionalDataProperty<ArcStr> {
     fn from(value: &FunctionalDataProperty) -> Self {
-        horned_owl::model::FunctionalDataProperty::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::FunctionalDataProperty::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for FunctionalDataProperty ****************/
 impl FromCompatible<horned_owl::model::FunctionalDataProperty<ArcStr>> for FunctionalDataProperty {
@@ -14322,43 +15273,59 @@ impl From<FunctionalDataProperty> for horned_owl::model::FunctionalDataProperty<
     }
 }
 
-impl From<&BoxWrap<FunctionalDataProperty>> for Box<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl From<&BoxWrap<FunctionalDataProperty>>
+    for Box<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from(value: &BoxWrap<FunctionalDataProperty>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::FunctionalDataProperty<ArcStr>>> for BoxWrap<FunctionalDataProperty> {
+impl From<&Box<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for BoxWrap<FunctionalDataProperty>
+{
     fn from(value: &Box<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<FunctionalDataProperty>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<FunctionalDataProperty>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<FunctionalDataProperty>> for Box<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl From<BoxWrap<FunctionalDataProperty>>
+    for Box<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from(value: BoxWrap<FunctionalDataProperty>) -> Self {
         Into::<Box<horned_owl::model::FunctionalDataProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::FunctionalDataProperty<ArcStr>>> for BoxWrap<FunctionalDataProperty> {
+impl From<Box<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for BoxWrap<FunctionalDataProperty>
+{
     fn from(value: Box<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         Into::<BoxWrap<FunctionalDataProperty>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<FunctionalDataProperty>> for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl From<VecWrap<FunctionalDataProperty>>
+    for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from(value: VecWrap<FunctionalDataProperty>) -> Self {
         Into::<Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>> for VecWrap<FunctionalDataProperty> {
+impl From<Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for VecWrap<FunctionalDataProperty>
+{
     fn from(value: Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         Into::<VecWrap<FunctionalDataProperty>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<FunctionalDataProperty>> for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl From<&VecWrap<FunctionalDataProperty>>
+    for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from(value: &VecWrap<FunctionalDataProperty>) -> Self {
         value
             .0
@@ -14367,48 +15334,66 @@ impl From<&VecWrap<FunctionalDataProperty>> for Vec<horned_owl::model::Functiona
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>> for VecWrap<FunctionalDataProperty> {
+impl From<&Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for VecWrap<FunctionalDataProperty>
+{
     fn from(value: &Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         VecWrap(value.iter().map(FunctionalDataProperty::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<FunctionalDataProperty>> for Box<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl FromCompatible<&BoxWrap<FunctionalDataProperty>>
+    for Box<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from_c(value: &BoxWrap<FunctionalDataProperty>) -> Self {
         Box::<horned_owl::model::FunctionalDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::FunctionalDataProperty<ArcStr>>> for BoxWrap<FunctionalDataProperty> {
+impl FromCompatible<&Box<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for BoxWrap<FunctionalDataProperty>
+{
     fn from_c(value: &Box<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         BoxWrap::<FunctionalDataProperty>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<FunctionalDataProperty>> for Box<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl FromCompatible<BoxWrap<FunctionalDataProperty>>
+    for Box<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from_c(value: BoxWrap<FunctionalDataProperty>) -> Self {
         Box::<horned_owl::model::FunctionalDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::FunctionalDataProperty<ArcStr>>> for BoxWrap<FunctionalDataProperty> {
+impl FromCompatible<Box<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for BoxWrap<FunctionalDataProperty>
+{
     fn from_c(value: Box<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         BoxWrap::<FunctionalDataProperty>::from(value)
     }
 }
-impl FromCompatible<VecWrap<FunctionalDataProperty>> for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl FromCompatible<VecWrap<FunctionalDataProperty>>
+    for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from_c(value: VecWrap<FunctionalDataProperty>) -> Self {
         Vec::<horned_owl::model::FunctionalDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>> for VecWrap<FunctionalDataProperty> {
+impl FromCompatible<Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for VecWrap<FunctionalDataProperty>
+{
     fn from_c(value: Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         VecWrap::<FunctionalDataProperty>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<FunctionalDataProperty>> for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>> {
+impl FromCompatible<&VecWrap<FunctionalDataProperty>>
+    for Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>
+{
     fn from_c(value: &VecWrap<FunctionalDataProperty>) -> Self {
         Vec::<horned_owl::model::FunctionalDataProperty<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>> for VecWrap<FunctionalDataProperty> {
+impl FromCompatible<&Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>>
+    for VecWrap<FunctionalDataProperty>
+{
     fn from_c(value: &Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>) -> Self {
         VecWrap::<FunctionalDataProperty>::from(value)
     }
@@ -14417,41 +15402,38 @@ impl FromCompatible<&Vec<horned_owl::model::FunctionalDataProperty<ArcStr>>> for
     "\n\n",
     doc!(DatatypeDefinition)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DatatypeDefinition {
-        #[doc="kind: Datatype"]
-        #[pyo3(get,set)]
-        pub kind: Datatype,
-    
-        #[doc="range: DataRange"]
-        #[pyo3(get,set)]
-        pub range: DataRange,
-    }
+    #[doc = "kind: Datatype"]
+    #[pyo3(get, set)]
+    pub kind: Datatype,
+
+    #[doc = "range: DataRange"]
+    #[pyo3(get, set)]
+    pub range: DataRange,
+}
 
 #[pymethods]
 impl DatatypeDefinition {
     #[new]
-    fn new(kind: Datatype,range: DataRange,) -> Self {
-        DatatypeDefinition {
-                kind,
-                range,
-        }
+    fn new(kind: Datatype, range: DataRange) -> Self {
+        DatatypeDefinition { kind, range }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "kind".to_string(),
-            "range".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("kind".to_string(), "range".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "kind" => self.kind.clone().into_pyobject(py).map(Bound::into_any),
             "range" => self.range.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -14460,12 +15442,15 @@ impl DatatypeDefinition {
             "kind" => {
                 self.kind = value.extract()?;
                 Ok(())
-            },
+            }
             "range" => {
                 self.range = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -14479,9 +15464,10 @@ impl DatatypeDefinition {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DatatypeDefinition<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DatatypeDefinition<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -14517,7 +15503,6 @@ impl From<&horned_owl::model::DatatypeDefinition<ArcStr>> for DatatypeDefinition
     }
 }
 
-
 impl From<&DatatypeDefinition> for horned_owl::model::DatatypeDefinition<ArcStr> {
     fn from(value: &DatatypeDefinition) -> Self {
         horned_owl::model::DatatypeDefinition::<ArcStr> {
@@ -14526,8 +15511,6 @@ impl From<&DatatypeDefinition> for horned_owl::model::DatatypeDefinition<ArcStr>
         }
     }
 }
-
-
 
 /**************** Base implementations for DatatypeDefinition ****************/
 impl FromCompatible<horned_owl::model::DatatypeDefinition<ArcStr>> for DatatypeDefinition {
@@ -14617,42 +15600,58 @@ impl From<&Vec<horned_owl::model::DatatypeDefinition<ArcStr>>> for VecWrap<Datat
     }
 }
 
-impl FromCompatible<&BoxWrap<DatatypeDefinition>> for Box<horned_owl::model::DatatypeDefinition<ArcStr>> {
+impl FromCompatible<&BoxWrap<DatatypeDefinition>>
+    for Box<horned_owl::model::DatatypeDefinition<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DatatypeDefinition>) -> Self {
         Box::<horned_owl::model::DatatypeDefinition<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DatatypeDefinition<ArcStr>>> for BoxWrap<DatatypeDefinition> {
+impl FromCompatible<&Box<horned_owl::model::DatatypeDefinition<ArcStr>>>
+    for BoxWrap<DatatypeDefinition>
+{
     fn from_c(value: &Box<horned_owl::model::DatatypeDefinition<ArcStr>>) -> Self {
         BoxWrap::<DatatypeDefinition>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DatatypeDefinition>> for Box<horned_owl::model::DatatypeDefinition<ArcStr>> {
+impl FromCompatible<BoxWrap<DatatypeDefinition>>
+    for Box<horned_owl::model::DatatypeDefinition<ArcStr>>
+{
     fn from_c(value: BoxWrap<DatatypeDefinition>) -> Self {
         Box::<horned_owl::model::DatatypeDefinition<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DatatypeDefinition<ArcStr>>> for BoxWrap<DatatypeDefinition> {
+impl FromCompatible<Box<horned_owl::model::DatatypeDefinition<ArcStr>>>
+    for BoxWrap<DatatypeDefinition>
+{
     fn from_c(value: Box<horned_owl::model::DatatypeDefinition<ArcStr>>) -> Self {
         BoxWrap::<DatatypeDefinition>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DatatypeDefinition>> for Vec<horned_owl::model::DatatypeDefinition<ArcStr>> {
+impl FromCompatible<VecWrap<DatatypeDefinition>>
+    for Vec<horned_owl::model::DatatypeDefinition<ArcStr>>
+{
     fn from_c(value: VecWrap<DatatypeDefinition>) -> Self {
         Vec::<horned_owl::model::DatatypeDefinition<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DatatypeDefinition<ArcStr>>> for VecWrap<DatatypeDefinition> {
+impl FromCompatible<Vec<horned_owl::model::DatatypeDefinition<ArcStr>>>
+    for VecWrap<DatatypeDefinition>
+{
     fn from_c(value: Vec<horned_owl::model::DatatypeDefinition<ArcStr>>) -> Self {
         VecWrap::<DatatypeDefinition>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DatatypeDefinition>> for Vec<horned_owl::model::DatatypeDefinition<ArcStr>> {
+impl FromCompatible<&VecWrap<DatatypeDefinition>>
+    for Vec<horned_owl::model::DatatypeDefinition<ArcStr>>
+{
     fn from_c(value: &VecWrap<DatatypeDefinition>) -> Self {
         Vec::<horned_owl::model::DatatypeDefinition<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DatatypeDefinition<ArcStr>>> for VecWrap<DatatypeDefinition> {
+impl FromCompatible<&Vec<horned_owl::model::DatatypeDefinition<ArcStr>>>
+    for VecWrap<DatatypeDefinition>
+{
     fn from_c(value: &Vec<horned_owl::model::DatatypeDefinition<ArcStr>>) -> Self {
         VecWrap::<DatatypeDefinition>::from(value)
     }
@@ -14661,41 +15660,38 @@ impl FromCompatible<&Vec<horned_owl::model::DatatypeDefinition<ArcStr>>> for Vec
     "\n\n",
     doc!(HasKey)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct HasKey {
-        #[doc="ce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub ce: ClassExpression,
-    
-        #[doc="vpe: typing.List[PropertyExpression]"]
-        #[pyo3(get,set)]
-        pub vpe: VecWrap<PropertyExpression>,
-    }
+    #[doc = "ce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub ce: ClassExpression,
+
+    #[doc = "vpe: typing.List[PropertyExpression]"]
+    #[pyo3(get, set)]
+    pub vpe: VecWrap<PropertyExpression>,
+}
 
 #[pymethods]
 impl HasKey {
     #[new]
-    fn new(ce: ClassExpression,vpe: VecWrap<PropertyExpression>,) -> Self {
-        HasKey {
-                ce,
-                vpe,
-        }
+    fn new(ce: ClassExpression, vpe: VecWrap<PropertyExpression>) -> Self {
+        HasKey { ce, vpe }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "ce".to_string(),
-            "vpe".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ce".to_string(), "vpe".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "ce" => self.ce.clone().into_pyobject(py).map(Bound::into_any),
             "vpe" => self.vpe.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -14704,12 +15700,15 @@ impl HasKey {
             "ce" => {
                 self.ce = value.extract()?;
                 Ok(())
-            },
+            }
             "vpe" => {
                 self.vpe = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -14723,9 +15722,10 @@ impl HasKey {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::HasKey<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::HasKey<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -14761,7 +15761,6 @@ impl From<&horned_owl::model::HasKey<ArcStr>> for HasKey {
     }
 }
 
-
 impl From<&HasKey> for horned_owl::model::HasKey<ArcStr> {
     fn from(value: &HasKey) -> Self {
         horned_owl::model::HasKey::<ArcStr> {
@@ -14770,8 +15769,6 @@ impl From<&HasKey> for horned_owl::model::HasKey<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for HasKey ****************/
 impl FromCompatible<horned_owl::model::HasKey<ArcStr>> for HasKey {
@@ -14906,26 +15903,24 @@ impl FromCompatible<&Vec<horned_owl::model::HasKey<ArcStr>>> for VecWrap<HasKey>
     "\n\n",
     doc!(SameIndividual)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct SameIndividual (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct SameIndividual(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<Individual>,
 );
 
 #[pymethods]
 impl SameIndividual {
     #[new]
-    fn new(first: VecWrap<Individual>,) -> Self {
-        SameIndividual (first,)
+    fn new(first: VecWrap<Individual>) -> Self {
+        SameIndividual(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -14938,9 +15933,10 @@ impl SameIndividual {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::SameIndividual<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::SameIndividual<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -14969,22 +15965,15 @@ impl SameIndividual {
 
 impl From<&horned_owl::model::SameIndividual<ArcStr>> for SameIndividual {
     fn from(value: &horned_owl::model::SameIndividual<ArcStr>) -> Self {
-
-        SameIndividual (
-    IntoCompatible::<VecWrap<Individual>>::into_c(&value.0),
-        )
+        SameIndividual(IntoCompatible::<VecWrap<Individual>>::into_c(&value.0))
     }
 }
 
 impl From<&SameIndividual> for horned_owl::model::SameIndividual<ArcStr> {
     fn from(value: &SameIndividual) -> Self {
-        horned_owl::model::SameIndividual::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::SameIndividual::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for SameIndividual ****************/
 impl FromCompatible<horned_owl::model::SameIndividual<ArcStr>> for SameIndividual {
@@ -15119,26 +16108,24 @@ impl FromCompatible<&Vec<horned_owl::model::SameIndividual<ArcStr>>> for VecWrap
     "\n\n",
     doc!(DifferentIndividuals)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DifferentIndividuals (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DifferentIndividuals(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub VecWrap<Individual>,
 );
 
 #[pymethods]
 impl DifferentIndividuals {
     #[new]
-    fn new(first: VecWrap<Individual>,) -> Self {
-        DifferentIndividuals (first,)
+    fn new(first: VecWrap<Individual>) -> Self {
+        DifferentIndividuals(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -15151,9 +16138,10 @@ impl DifferentIndividuals {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DifferentIndividuals<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DifferentIndividuals<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -15182,22 +16170,15 @@ impl DifferentIndividuals {
 
 impl From<&horned_owl::model::DifferentIndividuals<ArcStr>> for DifferentIndividuals {
     fn from(value: &horned_owl::model::DifferentIndividuals<ArcStr>) -> Self {
-
-        DifferentIndividuals (
-    IntoCompatible::<VecWrap<Individual>>::into_c(&value.0),
-        )
+        DifferentIndividuals(IntoCompatible::<VecWrap<Individual>>::into_c(&value.0))
     }
 }
 
 impl From<&DifferentIndividuals> for horned_owl::model::DifferentIndividuals<ArcStr> {
     fn from(value: &DifferentIndividuals) -> Self {
-        horned_owl::model::DifferentIndividuals::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DifferentIndividuals::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DifferentIndividuals ****************/
 impl FromCompatible<horned_owl::model::DifferentIndividuals<ArcStr>> for DifferentIndividuals {
@@ -15287,42 +16268,58 @@ impl From<&Vec<horned_owl::model::DifferentIndividuals<ArcStr>>> for VecWrap<Dif
     }
 }
 
-impl FromCompatible<&BoxWrap<DifferentIndividuals>> for Box<horned_owl::model::DifferentIndividuals<ArcStr>> {
+impl FromCompatible<&BoxWrap<DifferentIndividuals>>
+    for Box<horned_owl::model::DifferentIndividuals<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DifferentIndividuals>) -> Self {
         Box::<horned_owl::model::DifferentIndividuals<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DifferentIndividuals<ArcStr>>> for BoxWrap<DifferentIndividuals> {
+impl FromCompatible<&Box<horned_owl::model::DifferentIndividuals<ArcStr>>>
+    for BoxWrap<DifferentIndividuals>
+{
     fn from_c(value: &Box<horned_owl::model::DifferentIndividuals<ArcStr>>) -> Self {
         BoxWrap::<DifferentIndividuals>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DifferentIndividuals>> for Box<horned_owl::model::DifferentIndividuals<ArcStr>> {
+impl FromCompatible<BoxWrap<DifferentIndividuals>>
+    for Box<horned_owl::model::DifferentIndividuals<ArcStr>>
+{
     fn from_c(value: BoxWrap<DifferentIndividuals>) -> Self {
         Box::<horned_owl::model::DifferentIndividuals<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DifferentIndividuals<ArcStr>>> for BoxWrap<DifferentIndividuals> {
+impl FromCompatible<Box<horned_owl::model::DifferentIndividuals<ArcStr>>>
+    for BoxWrap<DifferentIndividuals>
+{
     fn from_c(value: Box<horned_owl::model::DifferentIndividuals<ArcStr>>) -> Self {
         BoxWrap::<DifferentIndividuals>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DifferentIndividuals>> for Vec<horned_owl::model::DifferentIndividuals<ArcStr>> {
+impl FromCompatible<VecWrap<DifferentIndividuals>>
+    for Vec<horned_owl::model::DifferentIndividuals<ArcStr>>
+{
     fn from_c(value: VecWrap<DifferentIndividuals>) -> Self {
         Vec::<horned_owl::model::DifferentIndividuals<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DifferentIndividuals<ArcStr>>> for VecWrap<DifferentIndividuals> {
+impl FromCompatible<Vec<horned_owl::model::DifferentIndividuals<ArcStr>>>
+    for VecWrap<DifferentIndividuals>
+{
     fn from_c(value: Vec<horned_owl::model::DifferentIndividuals<ArcStr>>) -> Self {
         VecWrap::<DifferentIndividuals>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DifferentIndividuals>> for Vec<horned_owl::model::DifferentIndividuals<ArcStr>> {
+impl FromCompatible<&VecWrap<DifferentIndividuals>>
+    for Vec<horned_owl::model::DifferentIndividuals<ArcStr>>
+{
     fn from_c(value: &VecWrap<DifferentIndividuals>) -> Self {
         Vec::<horned_owl::model::DifferentIndividuals<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DifferentIndividuals<ArcStr>>> for VecWrap<DifferentIndividuals> {
+impl FromCompatible<&Vec<horned_owl::model::DifferentIndividuals<ArcStr>>>
+    for VecWrap<DifferentIndividuals>
+{
     fn from_c(value: &Vec<horned_owl::model::DifferentIndividuals<ArcStr>>) -> Self {
         VecWrap::<DifferentIndividuals>::from(value)
     }
@@ -15331,41 +16328,38 @@ impl FromCompatible<&Vec<horned_owl::model::DifferentIndividuals<ArcStr>>> for V
     "\n\n",
     doc!(ClassAssertion)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ClassAssertion {
-        #[doc="ce: ClassExpression"]
-        #[pyo3(get,set)]
-        pub ce: ClassExpression,
-    
-        #[doc="i: Individual"]
-        #[pyo3(get,set)]
-        pub i: Individual,
-    }
+    #[doc = "ce: ClassExpression"]
+    #[pyo3(get, set)]
+    pub ce: ClassExpression,
+
+    #[doc = "i: Individual"]
+    #[pyo3(get, set)]
+    pub i: Individual,
+}
 
 #[pymethods]
 impl ClassAssertion {
     #[new]
-    fn new(ce: ClassExpression,i: Individual,) -> Self {
-        ClassAssertion {
-                ce,
-                i,
-        }
+    fn new(ce: ClassExpression, i: Individual) -> Self {
+        ClassAssertion { ce, i }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "ce".to_string(),
-            "i".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ce".to_string(), "i".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "ce" => self.ce.clone().into_pyobject(py).map(Bound::into_any),
             "i" => self.i.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -15374,12 +16368,15 @@ impl ClassAssertion {
             "ce" => {
                 self.ce = value.extract()?;
                 Ok(())
-            },
+            }
             "i" => {
                 self.i = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -15393,9 +16390,10 @@ impl ClassAssertion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::ClassAssertion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::ClassAssertion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -15431,7 +16429,6 @@ impl From<&horned_owl::model::ClassAssertion<ArcStr>> for ClassAssertion {
     }
 }
 
-
 impl From<&ClassAssertion> for horned_owl::model::ClassAssertion<ArcStr> {
     fn from(value: &ClassAssertion) -> Self {
         horned_owl::model::ClassAssertion::<ArcStr> {
@@ -15440,8 +16437,6 @@ impl From<&ClassAssertion> for horned_owl::model::ClassAssertion<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for ClassAssertion ****************/
 impl FromCompatible<horned_owl::model::ClassAssertion<ArcStr>> for ClassAssertion {
@@ -15575,40 +16570,36 @@ impl FromCompatible<&Vec<horned_owl::model::ClassAssertion<ArcStr>>> for VecWrap
     "\n\n",
     doc!(ObjectPropertyAssertion)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct ObjectPropertyAssertion {
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-    
-        #[doc="source: Individual"]
-        #[pyo3(get,set)]
-        pub source: Individual,
-    
-        #[doc="target: Individual"]
-        #[pyo3(get,set)]
-        pub target: Individual,
-    }
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+
+    #[doc = "source: Individual"]
+    #[pyo3(get, set)]
+    pub source: Individual,
+
+    #[doc = "target: Individual"]
+    #[pyo3(get, set)]
+    pub target: Individual,
+}
 
 #[pymethods]
 impl ObjectPropertyAssertion {
     #[new]
-    fn new(ope: ObjectPropertyExpression,source: Individual,target: Individual,) -> Self {
+    fn new(ope: ObjectPropertyExpression, source: Individual, target: Individual) -> Self {
         ObjectPropertyAssertion {
-                ope,
-                source,
-                target,
+            ope,
+            source,
+            target,
         }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String, String,)> {
-        Ok((
-            "ope".to_string(),
-            "from".to_string(),
-            "to".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("ope".to_string(), "from".to_string(), "to".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -15616,7 +16607,10 @@ impl ObjectPropertyAssertion {
             "ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any),
             "source" => self.source.clone().into_pyobject(py).map(Bound::into_any),
             "target" => self.target.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -15625,16 +16619,19 @@ impl ObjectPropertyAssertion {
             "ope" => {
                 self.ope = value.extract()?;
                 Ok(())
-            },
+            }
             "source" => {
                 self.source = value.extract()?;
                 Ok(())
-            },
+            }
             "target" => {
                 self.target = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -15648,9 +16645,10 @@ impl ObjectPropertyAssertion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::ObjectPropertyAssertion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::ObjectPropertyAssertion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -15687,7 +16685,6 @@ impl From<&horned_owl::model::ObjectPropertyAssertion<ArcStr>> for ObjectPropert
     }
 }
 
-
 impl From<&ObjectPropertyAssertion> for horned_owl::model::ObjectPropertyAssertion<ArcStr> {
     fn from(value: &ObjectPropertyAssertion) -> Self {
         horned_owl::model::ObjectPropertyAssertion::<ArcStr> {
@@ -15698,28 +16695,34 @@ impl From<&ObjectPropertyAssertion> for horned_owl::model::ObjectPropertyAsserti
     }
 }
 
-
-
 /**************** Base implementations for ObjectPropertyAssertion ****************/
-impl FromCompatible<horned_owl::model::ObjectPropertyAssertion<ArcStr>> for ObjectPropertyAssertion {
+impl FromCompatible<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+    for ObjectPropertyAssertion
+{
     fn from_c(value: horned_owl::model::ObjectPropertyAssertion<ArcStr>) -> Self {
         ObjectPropertyAssertion::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::ObjectPropertyAssertion<ArcStr>> for ObjectPropertyAssertion {
+impl FromCompatible<&horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+    for ObjectPropertyAssertion
+{
     fn from_c(value: &horned_owl::model::ObjectPropertyAssertion<ArcStr>) -> Self {
         ObjectPropertyAssertion::from(value)
     }
 }
 
-impl FromCompatible<ObjectPropertyAssertion> for horned_owl::model::ObjectPropertyAssertion<ArcStr> {
+impl FromCompatible<ObjectPropertyAssertion>
+    for horned_owl::model::ObjectPropertyAssertion<ArcStr>
+{
     fn from_c(value: ObjectPropertyAssertion) -> Self {
         horned_owl::model::ObjectPropertyAssertion::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&ObjectPropertyAssertion> for horned_owl::model::ObjectPropertyAssertion<ArcStr> {
+impl FromCompatible<&ObjectPropertyAssertion>
+    for horned_owl::model::ObjectPropertyAssertion<ArcStr>
+{
     fn from_c(value: &ObjectPropertyAssertion) -> Self {
         horned_owl::model::ObjectPropertyAssertion::<ArcStr>::from(value)
     }
@@ -15737,43 +16740,59 @@ impl From<ObjectPropertyAssertion> for horned_owl::model::ObjectPropertyAssertio
     }
 }
 
-impl From<&BoxWrap<ObjectPropertyAssertion>> for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl From<&BoxWrap<ObjectPropertyAssertion>>
+    for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: &BoxWrap<ObjectPropertyAssertion>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for BoxWrap<ObjectPropertyAssertion> {
+impl From<&Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<ObjectPropertyAssertion>
+{
     fn from(value: &Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<ObjectPropertyAssertion>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<ObjectPropertyAssertion>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<ObjectPropertyAssertion>> for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl From<BoxWrap<ObjectPropertyAssertion>>
+    for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: BoxWrap<ObjectPropertyAssertion>) -> Self {
         Into::<Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for BoxWrap<ObjectPropertyAssertion> {
+impl From<Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<ObjectPropertyAssertion>
+{
     fn from(value: Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         Into::<BoxWrap<ObjectPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<ObjectPropertyAssertion>> for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl From<VecWrap<ObjectPropertyAssertion>>
+    for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: VecWrap<ObjectPropertyAssertion>) -> Self {
         Into::<Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for VecWrap<ObjectPropertyAssertion> {
+impl From<Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<ObjectPropertyAssertion>
+{
     fn from(value: Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         Into::<VecWrap<ObjectPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<ObjectPropertyAssertion>> for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl From<&VecWrap<ObjectPropertyAssertion>>
+    for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: &VecWrap<ObjectPropertyAssertion>) -> Self {
         value
             .0
@@ -15782,48 +16801,66 @@ impl From<&VecWrap<ObjectPropertyAssertion>> for Vec<horned_owl::model::ObjectPr
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for VecWrap<ObjectPropertyAssertion> {
+impl From<&Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<ObjectPropertyAssertion>
+{
     fn from(value: &Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         VecWrap(value.iter().map(ObjectPropertyAssertion::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<ObjectPropertyAssertion>> for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<&BoxWrap<ObjectPropertyAssertion>>
+    for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &BoxWrap<ObjectPropertyAssertion>) -> Self {
         Box::<horned_owl::model::ObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for BoxWrap<ObjectPropertyAssertion> {
+impl FromCompatible<&Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<ObjectPropertyAssertion>
+{
     fn from_c(value: &Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<ObjectPropertyAssertion>> for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<BoxWrap<ObjectPropertyAssertion>>
+    for Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: BoxWrap<ObjectPropertyAssertion>) -> Self {
         Box::<horned_owl::model::ObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for BoxWrap<ObjectPropertyAssertion> {
+impl FromCompatible<Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<ObjectPropertyAssertion>
+{
     fn from_c(value: Box<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<ObjectPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<VecWrap<ObjectPropertyAssertion>> for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<VecWrap<ObjectPropertyAssertion>>
+    for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: VecWrap<ObjectPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for VecWrap<ObjectPropertyAssertion> {
+impl FromCompatible<Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<ObjectPropertyAssertion>
+{
     fn from_c(value: Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<ObjectPropertyAssertion>> for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<&VecWrap<ObjectPropertyAssertion>>
+    for Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &VecWrap<ObjectPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::ObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> for VecWrap<ObjectPropertyAssertion> {
+impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<ObjectPropertyAssertion>
+{
     fn from_c(value: &Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<ObjectPropertyAssertion>::from(value)
     }
@@ -15832,40 +16869,36 @@ impl FromCompatible<&Vec<horned_owl::model::ObjectPropertyAssertion<ArcStr>>> fo
     "\n\n",
     doc!(NegativeObjectPropertyAssertion)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NegativeObjectPropertyAssertion {
-        #[doc="ope: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub ope: ObjectPropertyExpression,
-    
-        #[doc="source: Individual"]
-        #[pyo3(get,set)]
-        pub source: Individual,
-    
-        #[doc="target: Individual"]
-        #[pyo3(get,set)]
-        pub target: Individual,
-    }
+    #[doc = "ope: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub ope: ObjectPropertyExpression,
+
+    #[doc = "source: Individual"]
+    #[pyo3(get, set)]
+    pub source: Individual,
+
+    #[doc = "target: Individual"]
+    #[pyo3(get, set)]
+    pub target: Individual,
+}
 
 #[pymethods]
 impl NegativeObjectPropertyAssertion {
     #[new]
-    fn new(ope: ObjectPropertyExpression,source: Individual,target: Individual,) -> Self {
+    fn new(ope: ObjectPropertyExpression, source: Individual, target: Individual) -> Self {
         NegativeObjectPropertyAssertion {
-                ope,
-                source,
-                target,
+            ope,
+            source,
+            target,
         }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String, String,)> {
-        Ok((
-            "ope".to_string(),
-            "from".to_string(),
-            "to".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("ope".to_string(), "from".to_string(), "to".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -15873,7 +16906,10 @@ impl NegativeObjectPropertyAssertion {
             "ope" => self.ope.clone().into_pyobject(py).map(Bound::into_any),
             "source" => self.source.clone().into_pyobject(py).map(Bound::into_any),
             "target" => self.target.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -15882,16 +16918,19 @@ impl NegativeObjectPropertyAssertion {
             "ope" => {
                 self.ope = value.extract()?;
                 Ok(())
-            },
+            }
             "source" => {
                 self.source = value.extract()?;
                 Ok(())
-            },
+            }
             "target" => {
                 self.target = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -15905,9 +16944,10 @@ impl NegativeObjectPropertyAssertion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -15934,7 +16974,9 @@ impl NegativeObjectPropertyAssertion {
     }
 }
 
-impl From<&horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> for NegativeObjectPropertyAssertion {
+impl From<&horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+    for NegativeObjectPropertyAssertion
+{
     fn from(value: &horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>) -> Self {
         NegativeObjectPropertyAssertion {
             ope: IntoCompatible::<ObjectPropertyExpression>::into_c(value.ope.borrow()),
@@ -15944,8 +16986,9 @@ impl From<&horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> for Negat
     }
 }
 
-
-impl From<&NegativeObjectPropertyAssertion> for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr> {
+impl From<&NegativeObjectPropertyAssertion>
+    for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>
+{
     fn from(value: &NegativeObjectPropertyAssertion) -> Self {
         horned_owl::model::NegativeObjectPropertyAssertion::<ArcStr> {
             ope: value.ope.borrow().into_c(),
@@ -15955,82 +16998,112 @@ impl From<&NegativeObjectPropertyAssertion> for horned_owl::model::NegativeObjec
     }
 }
 
-
-
 /**************** Base implementations for NegativeObjectPropertyAssertion ****************/
-impl FromCompatible<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> for NegativeObjectPropertyAssertion {
+impl FromCompatible<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+    for NegativeObjectPropertyAssertion
+{
     fn from_c(value: horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>) -> Self {
         NegativeObjectPropertyAssertion::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> for NegativeObjectPropertyAssertion {
+impl FromCompatible<&horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+    for NegativeObjectPropertyAssertion
+{
     fn from_c(value: &horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>) -> Self {
         NegativeObjectPropertyAssertion::from(value)
     }
 }
 
-impl FromCompatible<NegativeObjectPropertyAssertion> for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr> {
+impl FromCompatible<NegativeObjectPropertyAssertion>
+    for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>
+{
     fn from_c(value: NegativeObjectPropertyAssertion) -> Self {
         horned_owl::model::NegativeObjectPropertyAssertion::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&NegativeObjectPropertyAssertion> for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr> {
+impl FromCompatible<&NegativeObjectPropertyAssertion>
+    for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>
+{
     fn from_c(value: &NegativeObjectPropertyAssertion) -> Self {
         horned_owl::model::NegativeObjectPropertyAssertion::<ArcStr>::from(value)
     }
 }
 
-impl From<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> for NegativeObjectPropertyAssertion {
+impl From<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+    for NegativeObjectPropertyAssertion
+{
     fn from(value: horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>) -> Self {
         NegativeObjectPropertyAssertion::from(value.borrow())
     }
 }
 
-impl From<NegativeObjectPropertyAssertion> for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr> {
+impl From<NegativeObjectPropertyAssertion>
+    for horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>
+{
     fn from(value: NegativeObjectPropertyAssertion) -> Self {
         horned_owl::model::NegativeObjectPropertyAssertion::<ArcStr>::from(value.borrow())
     }
 }
 
-impl From<&BoxWrap<NegativeObjectPropertyAssertion>> for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl From<&BoxWrap<NegativeObjectPropertyAssertion>>
+    for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: &BoxWrap<NegativeObjectPropertyAssertion>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for BoxWrap<NegativeObjectPropertyAssertion> {
+impl From<&Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeObjectPropertyAssertion>
+{
     fn from(value: &Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<NegativeObjectPropertyAssertion>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<NegativeObjectPropertyAssertion>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<NegativeObjectPropertyAssertion>> for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl From<BoxWrap<NegativeObjectPropertyAssertion>>
+    for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: BoxWrap<NegativeObjectPropertyAssertion>) -> Self {
-        Into::<Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>::into(value.borrow())
+        Into::<Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>::into(
+            value.borrow(),
+        )
     }
 }
 
-impl From<Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for BoxWrap<NegativeObjectPropertyAssertion> {
+impl From<Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeObjectPropertyAssertion>
+{
     fn from(value: Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
         Into::<BoxWrap<NegativeObjectPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<NegativeObjectPropertyAssertion>> for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl From<VecWrap<NegativeObjectPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: VecWrap<NegativeObjectPropertyAssertion>) -> Self {
-        Into::<Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>::into(value.borrow())
+        Into::<Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>::into(
+            value.borrow(),
+        )
     }
 }
 
-impl From<Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for VecWrap<NegativeObjectPropertyAssertion> {
+impl From<Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeObjectPropertyAssertion>
+{
     fn from(value: Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
         Into::<VecWrap<NegativeObjectPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<NegativeObjectPropertyAssertion>> for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl From<&VecWrap<NegativeObjectPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from(value: &VecWrap<NegativeObjectPropertyAssertion>) -> Self {
         value
             .0
@@ -16039,48 +17112,71 @@ impl From<&VecWrap<NegativeObjectPropertyAssertion>> for Vec<horned_owl::model::
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for VecWrap<NegativeObjectPropertyAssertion> {
+impl From<&Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeObjectPropertyAssertion>
+{
     fn from(value: &Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
-        VecWrap(value.iter().map(NegativeObjectPropertyAssertion::from).collect())
+        VecWrap(
+            value
+                .iter()
+                .map(NegativeObjectPropertyAssertion::from)
+                .collect(),
+        )
     }
 }
 
-impl FromCompatible<&BoxWrap<NegativeObjectPropertyAssertion>> for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<&BoxWrap<NegativeObjectPropertyAssertion>>
+    for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &BoxWrap<NegativeObjectPropertyAssertion>) -> Self {
         Box::<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for BoxWrap<NegativeObjectPropertyAssertion> {
+impl FromCompatible<&Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeObjectPropertyAssertion>
+{
     fn from_c(value: &Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<NegativeObjectPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<NegativeObjectPropertyAssertion>> for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<BoxWrap<NegativeObjectPropertyAssertion>>
+    for Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: BoxWrap<NegativeObjectPropertyAssertion>) -> Self {
         Box::<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for BoxWrap<NegativeObjectPropertyAssertion> {
+impl FromCompatible<Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeObjectPropertyAssertion>
+{
     fn from_c(value: Box<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<NegativeObjectPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<VecWrap<NegativeObjectPropertyAssertion>> for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<VecWrap<NegativeObjectPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: VecWrap<NegativeObjectPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for VecWrap<NegativeObjectPropertyAssertion> {
+impl FromCompatible<Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeObjectPropertyAssertion>
+{
     fn from_c(value: Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<NegativeObjectPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<NegativeObjectPropertyAssertion>> for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>> {
+impl FromCompatible<&VecWrap<NegativeObjectPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &VecWrap<NegativeObjectPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>> for VecWrap<NegativeObjectPropertyAssertion> {
+impl FromCompatible<&Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeObjectPropertyAssertion>
+{
     fn from_c(value: &Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<NegativeObjectPropertyAssertion>::from(value)
     }
@@ -16089,40 +17185,32 @@ impl FromCompatible<&Vec<horned_owl::model::NegativeObjectPropertyAssertion<ArcS
     "\n\n",
     doc!(DataPropertyAssertion)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct DataPropertyAssertion {
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-    
-        #[doc="source: Individual"]
-        #[pyo3(get,set)]
-        pub source: Individual,
-    
-        #[doc="target: Literal"]
-        #[pyo3(get,set)]
-        pub target: Literal,
-    }
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+
+    #[doc = "source: Individual"]
+    #[pyo3(get, set)]
+    pub source: Individual,
+
+    #[doc = "target: Literal"]
+    #[pyo3(get, set)]
+    pub target: Literal,
+}
 
 #[pymethods]
 impl DataPropertyAssertion {
     #[new]
-    fn new(dp: DataProperty,source: Individual,target: Literal,) -> Self {
-        DataPropertyAssertion {
-                dp,
-                source,
-                target,
-        }
+    fn new(dp: DataProperty, source: Individual, target: Literal) -> Self {
+        DataPropertyAssertion { dp, source, target }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String, String,)> {
-        Ok((
-            "dp".to_string(),
-            "from".to_string(),
-            "to".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("dp".to_string(), "from".to_string(), "to".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -16130,7 +17218,10 @@ impl DataPropertyAssertion {
             "dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any),
             "source" => self.source.clone().into_pyobject(py).map(Bound::into_any),
             "target" => self.target.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16139,16 +17230,19 @@ impl DataPropertyAssertion {
             "dp" => {
                 self.dp = value.extract()?;
                 Ok(())
-            },
+            }
             "source" => {
                 self.source = value.extract()?;
                 Ok(())
-            },
+            }
             "target" => {
                 self.target = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16162,9 +17256,10 @@ impl DataPropertyAssertion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DataPropertyAssertion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DataPropertyAssertion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -16201,7 +17296,6 @@ impl From<&horned_owl::model::DataPropertyAssertion<ArcStr>> for DataPropertyAss
     }
 }
 
-
 impl From<&DataPropertyAssertion> for horned_owl::model::DataPropertyAssertion<ArcStr> {
     fn from(value: &DataPropertyAssertion) -> Self {
         horned_owl::model::DataPropertyAssertion::<ArcStr> {
@@ -16211,8 +17305,6 @@ impl From<&DataPropertyAssertion> for horned_owl::model::DataPropertyAssertion<A
         }
     }
 }
-
-
 
 /**************** Base implementations for DataPropertyAssertion ****************/
 impl FromCompatible<horned_owl::model::DataPropertyAssertion<ArcStr>> for DataPropertyAssertion {
@@ -16251,43 +17343,59 @@ impl From<DataPropertyAssertion> for horned_owl::model::DataPropertyAssertion<Ar
     }
 }
 
-impl From<&BoxWrap<DataPropertyAssertion>> for Box<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl From<&BoxWrap<DataPropertyAssertion>>
+    for Box<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from(value: &BoxWrap<DataPropertyAssertion>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::DataPropertyAssertion<ArcStr>>> for BoxWrap<DataPropertyAssertion> {
+impl From<&Box<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for BoxWrap<DataPropertyAssertion>
+{
     fn from(value: &Box<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<DataPropertyAssertion>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<DataPropertyAssertion>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<DataPropertyAssertion>> for Box<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl From<BoxWrap<DataPropertyAssertion>>
+    for Box<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from(value: BoxWrap<DataPropertyAssertion>) -> Self {
         Into::<Box<horned_owl::model::DataPropertyAssertion<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::DataPropertyAssertion<ArcStr>>> for BoxWrap<DataPropertyAssertion> {
+impl From<Box<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for BoxWrap<DataPropertyAssertion>
+{
     fn from(value: Box<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         Into::<BoxWrap<DataPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<DataPropertyAssertion>> for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl From<VecWrap<DataPropertyAssertion>>
+    for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from(value: VecWrap<DataPropertyAssertion>) -> Self {
         Into::<Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>> for VecWrap<DataPropertyAssertion> {
+impl From<Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for VecWrap<DataPropertyAssertion>
+{
     fn from(value: Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         Into::<VecWrap<DataPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<DataPropertyAssertion>> for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl From<&VecWrap<DataPropertyAssertion>>
+    for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from(value: &VecWrap<DataPropertyAssertion>) -> Self {
         value
             .0
@@ -16296,48 +17404,66 @@ impl From<&VecWrap<DataPropertyAssertion>> for Vec<horned_owl::model::DataProper
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>> for VecWrap<DataPropertyAssertion> {
+impl From<&Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for VecWrap<DataPropertyAssertion>
+{
     fn from(value: &Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         VecWrap(value.iter().map(DataPropertyAssertion::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<DataPropertyAssertion>> for Box<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl FromCompatible<&BoxWrap<DataPropertyAssertion>>
+    for Box<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &BoxWrap<DataPropertyAssertion>) -> Self {
         Box::<horned_owl::model::DataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::DataPropertyAssertion<ArcStr>>> for BoxWrap<DataPropertyAssertion> {
+impl FromCompatible<&Box<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for BoxWrap<DataPropertyAssertion>
+{
     fn from_c(value: &Box<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<DataPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<DataPropertyAssertion>> for Box<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl FromCompatible<BoxWrap<DataPropertyAssertion>>
+    for Box<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: BoxWrap<DataPropertyAssertion>) -> Self {
         Box::<horned_owl::model::DataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::DataPropertyAssertion<ArcStr>>> for BoxWrap<DataPropertyAssertion> {
+impl FromCompatible<Box<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for BoxWrap<DataPropertyAssertion>
+{
     fn from_c(value: Box<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<DataPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<VecWrap<DataPropertyAssertion>> for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl FromCompatible<VecWrap<DataPropertyAssertion>>
+    for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: VecWrap<DataPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::DataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>> for VecWrap<DataPropertyAssertion> {
+impl FromCompatible<Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for VecWrap<DataPropertyAssertion>
+{
     fn from_c(value: Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<DataPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<DataPropertyAssertion>> for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>> {
+impl FromCompatible<&VecWrap<DataPropertyAssertion>>
+    for Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &VecWrap<DataPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::DataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>> for VecWrap<DataPropertyAssertion> {
+impl FromCompatible<&Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>>
+    for VecWrap<DataPropertyAssertion>
+{
     fn from_c(value: &Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<DataPropertyAssertion>::from(value)
     }
@@ -16346,40 +17472,32 @@ impl FromCompatible<&Vec<horned_owl::model::DataPropertyAssertion<ArcStr>>> for 
     "\n\n",
     doc!(NegativeDataPropertyAssertion)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct NegativeDataPropertyAssertion {
-        #[doc="dp: DataProperty"]
-        #[pyo3(get,set)]
-        pub dp: DataProperty,
-    
-        #[doc="source: Individual"]
-        #[pyo3(get,set)]
-        pub source: Individual,
-    
-        #[doc="target: Literal"]
-        #[pyo3(get,set)]
-        pub target: Literal,
-    }
+    #[doc = "dp: DataProperty"]
+    #[pyo3(get, set)]
+    pub dp: DataProperty,
+
+    #[doc = "source: Individual"]
+    #[pyo3(get, set)]
+    pub source: Individual,
+
+    #[doc = "target: Literal"]
+    #[pyo3(get, set)]
+    pub target: Literal,
+}
 
 #[pymethods]
 impl NegativeDataPropertyAssertion {
     #[new]
-    fn new(dp: DataProperty,source: Individual,target: Literal,) -> Self {
-        NegativeDataPropertyAssertion {
-                dp,
-                source,
-                target,
-        }
+    fn new(dp: DataProperty, source: Individual, target: Literal) -> Self {
+        NegativeDataPropertyAssertion { dp, source, target }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String, String,)> {
-        Ok((
-            "dp".to_string(),
-            "from".to_string(),
-            "to".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String, String)> {
+        Ok(("dp".to_string(), "from".to_string(), "to".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
@@ -16387,7 +17505,10 @@ impl NegativeDataPropertyAssertion {
             "dp" => self.dp.clone().into_pyobject(py).map(Bound::into_any),
             "source" => self.source.clone().into_pyobject(py).map(Bound::into_any),
             "target" => self.target.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16396,16 +17517,19 @@ impl NegativeDataPropertyAssertion {
             "dp" => {
                 self.dp = value.extract()?;
                 Ok(())
-            },
+            }
             "source" => {
                 self.source = value.extract()?;
                 Ok(())
-            },
+            }
             "target" => {
                 self.target = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16419,9 +17543,10 @@ impl NegativeDataPropertyAssertion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -16448,7 +17573,9 @@ impl NegativeDataPropertyAssertion {
     }
 }
 
-impl From<&horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> for NegativeDataPropertyAssertion {
+impl From<&horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+    for NegativeDataPropertyAssertion
+{
     fn from(value: &horned_owl::model::NegativeDataPropertyAssertion<ArcStr>) -> Self {
         NegativeDataPropertyAssertion {
             dp: IntoCompatible::<DataProperty>::into_c(value.dp.borrow()),
@@ -16458,8 +17585,9 @@ impl From<&horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> for Negativ
     }
 }
 
-
-impl From<&NegativeDataPropertyAssertion> for horned_owl::model::NegativeDataPropertyAssertion<ArcStr> {
+impl From<&NegativeDataPropertyAssertion>
+    for horned_owl::model::NegativeDataPropertyAssertion<ArcStr>
+{
     fn from(value: &NegativeDataPropertyAssertion) -> Self {
         horned_owl::model::NegativeDataPropertyAssertion::<ArcStr> {
             dp: value.dp.borrow().into_c(),
@@ -16469,82 +17597,108 @@ impl From<&NegativeDataPropertyAssertion> for horned_owl::model::NegativeDataPro
     }
 }
 
-
-
 /**************** Base implementations for NegativeDataPropertyAssertion ****************/
-impl FromCompatible<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> for NegativeDataPropertyAssertion {
+impl FromCompatible<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+    for NegativeDataPropertyAssertion
+{
     fn from_c(value: horned_owl::model::NegativeDataPropertyAssertion<ArcStr>) -> Self {
         NegativeDataPropertyAssertion::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> for NegativeDataPropertyAssertion {
+impl FromCompatible<&horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+    for NegativeDataPropertyAssertion
+{
     fn from_c(value: &horned_owl::model::NegativeDataPropertyAssertion<ArcStr>) -> Self {
         NegativeDataPropertyAssertion::from(value)
     }
 }
 
-impl FromCompatible<NegativeDataPropertyAssertion> for horned_owl::model::NegativeDataPropertyAssertion<ArcStr> {
+impl FromCompatible<NegativeDataPropertyAssertion>
+    for horned_owl::model::NegativeDataPropertyAssertion<ArcStr>
+{
     fn from_c(value: NegativeDataPropertyAssertion) -> Self {
         horned_owl::model::NegativeDataPropertyAssertion::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&NegativeDataPropertyAssertion> for horned_owl::model::NegativeDataPropertyAssertion<ArcStr> {
+impl FromCompatible<&NegativeDataPropertyAssertion>
+    for horned_owl::model::NegativeDataPropertyAssertion<ArcStr>
+{
     fn from_c(value: &NegativeDataPropertyAssertion) -> Self {
         horned_owl::model::NegativeDataPropertyAssertion::<ArcStr>::from(value)
     }
 }
 
-impl From<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> for NegativeDataPropertyAssertion {
+impl From<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+    for NegativeDataPropertyAssertion
+{
     fn from(value: horned_owl::model::NegativeDataPropertyAssertion<ArcStr>) -> Self {
         NegativeDataPropertyAssertion::from(value.borrow())
     }
 }
 
-impl From<NegativeDataPropertyAssertion> for horned_owl::model::NegativeDataPropertyAssertion<ArcStr> {
+impl From<NegativeDataPropertyAssertion>
+    for horned_owl::model::NegativeDataPropertyAssertion<ArcStr>
+{
     fn from(value: NegativeDataPropertyAssertion) -> Self {
         horned_owl::model::NegativeDataPropertyAssertion::<ArcStr>::from(value.borrow())
     }
 }
 
-impl From<&BoxWrap<NegativeDataPropertyAssertion>> for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl From<&BoxWrap<NegativeDataPropertyAssertion>>
+    for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from(value: &BoxWrap<NegativeDataPropertyAssertion>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for BoxWrap<NegativeDataPropertyAssertion> {
+impl From<&Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeDataPropertyAssertion>
+{
     fn from(value: &Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<NegativeDataPropertyAssertion>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<NegativeDataPropertyAssertion>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<NegativeDataPropertyAssertion>> for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl From<BoxWrap<NegativeDataPropertyAssertion>>
+    for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from(value: BoxWrap<NegativeDataPropertyAssertion>) -> Self {
         Into::<Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for BoxWrap<NegativeDataPropertyAssertion> {
+impl From<Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeDataPropertyAssertion>
+{
     fn from(value: Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
         Into::<BoxWrap<NegativeDataPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<NegativeDataPropertyAssertion>> for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl From<VecWrap<NegativeDataPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from(value: VecWrap<NegativeDataPropertyAssertion>) -> Self {
         Into::<Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for VecWrap<NegativeDataPropertyAssertion> {
+impl From<Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeDataPropertyAssertion>
+{
     fn from(value: Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
         Into::<VecWrap<NegativeDataPropertyAssertion>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<NegativeDataPropertyAssertion>> for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl From<&VecWrap<NegativeDataPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from(value: &VecWrap<NegativeDataPropertyAssertion>) -> Self {
         value
             .0
@@ -16553,48 +17707,71 @@ impl From<&VecWrap<NegativeDataPropertyAssertion>> for Vec<horned_owl::model::Ne
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for VecWrap<NegativeDataPropertyAssertion> {
+impl From<&Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeDataPropertyAssertion>
+{
     fn from(value: &Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
-        VecWrap(value.iter().map(NegativeDataPropertyAssertion::from).collect())
+        VecWrap(
+            value
+                .iter()
+                .map(NegativeDataPropertyAssertion::from)
+                .collect(),
+        )
     }
 }
 
-impl FromCompatible<&BoxWrap<NegativeDataPropertyAssertion>> for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl FromCompatible<&BoxWrap<NegativeDataPropertyAssertion>>
+    for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &BoxWrap<NegativeDataPropertyAssertion>) -> Self {
         Box::<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for BoxWrap<NegativeDataPropertyAssertion> {
+impl FromCompatible<&Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeDataPropertyAssertion>
+{
     fn from_c(value: &Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<NegativeDataPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<NegativeDataPropertyAssertion>> for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl FromCompatible<BoxWrap<NegativeDataPropertyAssertion>>
+    for Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: BoxWrap<NegativeDataPropertyAssertion>) -> Self {
         Box::<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for BoxWrap<NegativeDataPropertyAssertion> {
+impl FromCompatible<Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for BoxWrap<NegativeDataPropertyAssertion>
+{
     fn from_c(value: Box<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
         BoxWrap::<NegativeDataPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<VecWrap<NegativeDataPropertyAssertion>> for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl FromCompatible<VecWrap<NegativeDataPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: VecWrap<NegativeDataPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for VecWrap<NegativeDataPropertyAssertion> {
+impl FromCompatible<Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeDataPropertyAssertion>
+{
     fn from_c(value: Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<NegativeDataPropertyAssertion>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<NegativeDataPropertyAssertion>> for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>> {
+impl FromCompatible<&VecWrap<NegativeDataPropertyAssertion>>
+    for Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>
+{
     fn from_c(value: &VecWrap<NegativeDataPropertyAssertion>) -> Self {
         Vec::<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>> for VecWrap<NegativeDataPropertyAssertion> {
+impl FromCompatible<&Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>>
+    for VecWrap<NegativeDataPropertyAssertion>
+{
     fn from_c(value: &Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr>>) -> Self {
         VecWrap::<NegativeDataPropertyAssertion>::from(value)
     }
@@ -16603,41 +17780,38 @@ impl FromCompatible<&Vec<horned_owl::model::NegativeDataPropertyAssertion<ArcStr
     "\n\n",
     doc!(AnnotationAssertion)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnnotationAssertion {
-        #[doc="subject: AnnotationSubject"]
-        #[pyo3(get,set)]
-        pub subject: AnnotationSubject,
-    
-        #[doc="ann: Annotation"]
-        #[pyo3(get,set)]
-        pub ann: Annotation,
-    }
+    #[doc = "subject: AnnotationSubject"]
+    #[pyo3(get, set)]
+    pub subject: AnnotationSubject,
+
+    #[doc = "ann: Annotation"]
+    #[pyo3(get, set)]
+    pub ann: Annotation,
+}
 
 #[pymethods]
 impl AnnotationAssertion {
     #[new]
-    fn new(subject: AnnotationSubject,ann: Annotation,) -> Self {
-        AnnotationAssertion {
-                subject,
-                ann,
-        }
+    fn new(subject: AnnotationSubject, ann: Annotation) -> Self {
+        AnnotationAssertion { subject, ann }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "subject".to_string(),
-            "ann".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("subject".to_string(), "ann".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "subject" => self.subject.clone().into_pyobject(py).map(Bound::into_any),
             "ann" => self.ann.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16646,12 +17820,15 @@ impl AnnotationAssertion {
             "subject" => {
                 self.subject = value.extract()?;
                 Ok(())
-            },
+            }
             "ann" => {
                 self.ann = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16665,9 +17842,10 @@ impl AnnotationAssertion {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::AnnotationAssertion<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::AnnotationAssertion<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -16703,7 +17881,6 @@ impl From<&horned_owl::model::AnnotationAssertion<ArcStr>> for AnnotationAsserti
     }
 }
 
-
 impl From<&AnnotationAssertion> for horned_owl::model::AnnotationAssertion<ArcStr> {
     fn from(value: &AnnotationAssertion) -> Self {
         horned_owl::model::AnnotationAssertion::<ArcStr> {
@@ -16712,8 +17889,6 @@ impl From<&AnnotationAssertion> for horned_owl::model::AnnotationAssertion<ArcSt
         }
     }
 }
-
-
 
 /**************** Base implementations for AnnotationAssertion ****************/
 impl FromCompatible<horned_owl::model::AnnotationAssertion<ArcStr>> for AnnotationAssertion {
@@ -16803,42 +17978,58 @@ impl From<&Vec<horned_owl::model::AnnotationAssertion<ArcStr>>> for VecWrap<Anno
     }
 }
 
-impl FromCompatible<&BoxWrap<AnnotationAssertion>> for Box<horned_owl::model::AnnotationAssertion<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnnotationAssertion>>
+    for Box<horned_owl::model::AnnotationAssertion<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnnotationAssertion>) -> Self {
         Box::<horned_owl::model::AnnotationAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnnotationAssertion<ArcStr>>> for BoxWrap<AnnotationAssertion> {
+impl FromCompatible<&Box<horned_owl::model::AnnotationAssertion<ArcStr>>>
+    for BoxWrap<AnnotationAssertion>
+{
     fn from_c(value: &Box<horned_owl::model::AnnotationAssertion<ArcStr>>) -> Self {
         BoxWrap::<AnnotationAssertion>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnnotationAssertion>> for Box<horned_owl::model::AnnotationAssertion<ArcStr>> {
+impl FromCompatible<BoxWrap<AnnotationAssertion>>
+    for Box<horned_owl::model::AnnotationAssertion<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnnotationAssertion>) -> Self {
         Box::<horned_owl::model::AnnotationAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnnotationAssertion<ArcStr>>> for BoxWrap<AnnotationAssertion> {
+impl FromCompatible<Box<horned_owl::model::AnnotationAssertion<ArcStr>>>
+    for BoxWrap<AnnotationAssertion>
+{
     fn from_c(value: Box<horned_owl::model::AnnotationAssertion<ArcStr>>) -> Self {
         BoxWrap::<AnnotationAssertion>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnnotationAssertion>> for Vec<horned_owl::model::AnnotationAssertion<ArcStr>> {
+impl FromCompatible<VecWrap<AnnotationAssertion>>
+    for Vec<horned_owl::model::AnnotationAssertion<ArcStr>>
+{
     fn from_c(value: VecWrap<AnnotationAssertion>) -> Self {
         Vec::<horned_owl::model::AnnotationAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnnotationAssertion<ArcStr>>> for VecWrap<AnnotationAssertion> {
+impl FromCompatible<Vec<horned_owl::model::AnnotationAssertion<ArcStr>>>
+    for VecWrap<AnnotationAssertion>
+{
     fn from_c(value: Vec<horned_owl::model::AnnotationAssertion<ArcStr>>) -> Self {
         VecWrap::<AnnotationAssertion>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnnotationAssertion>> for Vec<horned_owl::model::AnnotationAssertion<ArcStr>> {
+impl FromCompatible<&VecWrap<AnnotationAssertion>>
+    for Vec<horned_owl::model::AnnotationAssertion<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnnotationAssertion>) -> Self {
         Vec::<horned_owl::model::AnnotationAssertion<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnnotationAssertion<ArcStr>>> for VecWrap<AnnotationAssertion> {
+impl FromCompatible<&Vec<horned_owl::model::AnnotationAssertion<ArcStr>>>
+    for VecWrap<AnnotationAssertion>
+{
     fn from_c(value: &Vec<horned_owl::model::AnnotationAssertion<ArcStr>>) -> Self {
         VecWrap::<AnnotationAssertion>::from(value)
     }
@@ -16847,41 +18038,38 @@ impl FromCompatible<&Vec<horned_owl::model::AnnotationAssertion<ArcStr>>> for Ve
     "\n\n",
     doc!(SubAnnotationPropertyOf)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct SubAnnotationPropertyOf {
-        #[doc="sub: AnnotationProperty"]
-        #[pyo3(get,set)]
-        pub sub: AnnotationProperty,
-    
-        #[doc="sup: AnnotationProperty"]
-        #[pyo3(get,set)]
-        pub sup: AnnotationProperty,
-    }
+    #[doc = "sub: AnnotationProperty"]
+    #[pyo3(get, set)]
+    pub sub: AnnotationProperty,
+
+    #[doc = "sup: AnnotationProperty"]
+    #[pyo3(get, set)]
+    pub sup: AnnotationProperty,
+}
 
 #[pymethods]
 impl SubAnnotationPropertyOf {
     #[new]
-    fn new(sub: AnnotationProperty,sup: AnnotationProperty,) -> Self {
-        SubAnnotationPropertyOf {
-                sub,
-                sup,
-        }
+    fn new(sub: AnnotationProperty, sup: AnnotationProperty) -> Self {
+        SubAnnotationPropertyOf { sub, sup }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "sub".to_string(),
-            "sup".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("sub".to_string(), "sup".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "sub" => self.sub.clone().into_pyobject(py).map(Bound::into_any),
             "sup" => self.sup.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16890,12 +18078,15 @@ impl SubAnnotationPropertyOf {
             "sub" => {
                 self.sub = value.extract()?;
                 Ok(())
-            },
+            }
             "sup" => {
                 self.sup = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -16909,9 +18100,10 @@ impl SubAnnotationPropertyOf {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -16947,7 +18139,6 @@ impl From<&horned_owl::model::SubAnnotationPropertyOf<ArcStr>> for SubAnnotation
     }
 }
 
-
 impl From<&SubAnnotationPropertyOf> for horned_owl::model::SubAnnotationPropertyOf<ArcStr> {
     fn from(value: &SubAnnotationPropertyOf) -> Self {
         horned_owl::model::SubAnnotationPropertyOf::<ArcStr> {
@@ -16957,28 +18148,34 @@ impl From<&SubAnnotationPropertyOf> for horned_owl::model::SubAnnotationProperty
     }
 }
 
-
-
 /**************** Base implementations for SubAnnotationPropertyOf ****************/
-impl FromCompatible<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> for SubAnnotationPropertyOf {
+impl FromCompatible<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+    for SubAnnotationPropertyOf
+{
     fn from_c(value: horned_owl::model::SubAnnotationPropertyOf<ArcStr>) -> Self {
         SubAnnotationPropertyOf::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::SubAnnotationPropertyOf<ArcStr>> for SubAnnotationPropertyOf {
+impl FromCompatible<&horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+    for SubAnnotationPropertyOf
+{
     fn from_c(value: &horned_owl::model::SubAnnotationPropertyOf<ArcStr>) -> Self {
         SubAnnotationPropertyOf::from(value)
     }
 }
 
-impl FromCompatible<SubAnnotationPropertyOf> for horned_owl::model::SubAnnotationPropertyOf<ArcStr> {
+impl FromCompatible<SubAnnotationPropertyOf>
+    for horned_owl::model::SubAnnotationPropertyOf<ArcStr>
+{
     fn from_c(value: SubAnnotationPropertyOf) -> Self {
         horned_owl::model::SubAnnotationPropertyOf::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&SubAnnotationPropertyOf> for horned_owl::model::SubAnnotationPropertyOf<ArcStr> {
+impl FromCompatible<&SubAnnotationPropertyOf>
+    for horned_owl::model::SubAnnotationPropertyOf<ArcStr>
+{
     fn from_c(value: &SubAnnotationPropertyOf) -> Self {
         horned_owl::model::SubAnnotationPropertyOf::<ArcStr>::from(value)
     }
@@ -16996,43 +18193,59 @@ impl From<SubAnnotationPropertyOf> for horned_owl::model::SubAnnotationPropertyO
     }
 }
 
-impl From<&BoxWrap<SubAnnotationPropertyOf>> for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl From<&BoxWrap<SubAnnotationPropertyOf>>
+    for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from(value: &BoxWrap<SubAnnotationPropertyOf>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for BoxWrap<SubAnnotationPropertyOf> {
+impl From<&Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for BoxWrap<SubAnnotationPropertyOf>
+{
     fn from(value: &Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<SubAnnotationPropertyOf>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<SubAnnotationPropertyOf>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<SubAnnotationPropertyOf>> for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl From<BoxWrap<SubAnnotationPropertyOf>>
+    for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from(value: BoxWrap<SubAnnotationPropertyOf>) -> Self {
         Into::<Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for BoxWrap<SubAnnotationPropertyOf> {
+impl From<Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for BoxWrap<SubAnnotationPropertyOf>
+{
     fn from(value: Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         Into::<BoxWrap<SubAnnotationPropertyOf>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<SubAnnotationPropertyOf>> for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl From<VecWrap<SubAnnotationPropertyOf>>
+    for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from(value: VecWrap<SubAnnotationPropertyOf>) -> Self {
         Into::<Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for VecWrap<SubAnnotationPropertyOf> {
+impl From<Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for VecWrap<SubAnnotationPropertyOf>
+{
     fn from(value: Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         Into::<VecWrap<SubAnnotationPropertyOf>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<SubAnnotationPropertyOf>> for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl From<&VecWrap<SubAnnotationPropertyOf>>
+    for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from(value: &VecWrap<SubAnnotationPropertyOf>) -> Self {
         value
             .0
@@ -17041,48 +18254,66 @@ impl From<&VecWrap<SubAnnotationPropertyOf>> for Vec<horned_owl::model::SubAnnot
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for VecWrap<SubAnnotationPropertyOf> {
+impl From<&Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for VecWrap<SubAnnotationPropertyOf>
+{
     fn from(value: &Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         VecWrap(value.iter().map(SubAnnotationPropertyOf::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<SubAnnotationPropertyOf>> for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl FromCompatible<&BoxWrap<SubAnnotationPropertyOf>>
+    for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from_c(value: &BoxWrap<SubAnnotationPropertyOf>) -> Self {
         Box::<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for BoxWrap<SubAnnotationPropertyOf> {
+impl FromCompatible<&Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for BoxWrap<SubAnnotationPropertyOf>
+{
     fn from_c(value: &Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         BoxWrap::<SubAnnotationPropertyOf>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<SubAnnotationPropertyOf>> for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl FromCompatible<BoxWrap<SubAnnotationPropertyOf>>
+    for Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from_c(value: BoxWrap<SubAnnotationPropertyOf>) -> Self {
         Box::<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for BoxWrap<SubAnnotationPropertyOf> {
+impl FromCompatible<Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for BoxWrap<SubAnnotationPropertyOf>
+{
     fn from_c(value: Box<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         BoxWrap::<SubAnnotationPropertyOf>::from(value)
     }
 }
-impl FromCompatible<VecWrap<SubAnnotationPropertyOf>> for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl FromCompatible<VecWrap<SubAnnotationPropertyOf>>
+    for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from_c(value: VecWrap<SubAnnotationPropertyOf>) -> Self {
         Vec::<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for VecWrap<SubAnnotationPropertyOf> {
+impl FromCompatible<Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for VecWrap<SubAnnotationPropertyOf>
+{
     fn from_c(value: Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         VecWrap::<SubAnnotationPropertyOf>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<SubAnnotationPropertyOf>> for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>> {
+impl FromCompatible<&VecWrap<SubAnnotationPropertyOf>>
+    for Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>
+{
     fn from_c(value: &VecWrap<SubAnnotationPropertyOf>) -> Self {
         Vec::<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> for VecWrap<SubAnnotationPropertyOf> {
+impl FromCompatible<&Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>>
+    for VecWrap<SubAnnotationPropertyOf>
+{
     fn from_c(value: &Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>) -> Self {
         VecWrap::<SubAnnotationPropertyOf>::from(value)
     }
@@ -17091,41 +18322,38 @@ impl FromCompatible<&Vec<horned_owl::model::SubAnnotationPropertyOf<ArcStr>>> fo
     "\n\n",
     doc!(AnnotationPropertyDomain)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnnotationPropertyDomain {
-        #[doc="ap: AnnotationProperty"]
-        #[pyo3(get,set)]
-        pub ap: AnnotationProperty,
-    
-        #[doc="iri: IRI"]
-        #[pyo3(get,set)]
-        pub iri: IRI,
-    }
+    #[doc = "ap: AnnotationProperty"]
+    #[pyo3(get, set)]
+    pub ap: AnnotationProperty,
+
+    #[doc = "iri: IRI"]
+    #[pyo3(get, set)]
+    pub iri: IRI,
+}
 
 #[pymethods]
 impl AnnotationPropertyDomain {
     #[new]
-    fn new(ap: AnnotationProperty,iri: IRI,) -> Self {
-        AnnotationPropertyDomain {
-                ap,
-                iri,
-        }
+    fn new(ap: AnnotationProperty, iri: IRI) -> Self {
+        AnnotationPropertyDomain { ap, iri }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "ap".to_string(),
-            "iri".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ap".to_string(), "iri".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "ap" => self.ap.clone().into_pyobject(py).map(Bound::into_any),
             "iri" => self.iri.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -17134,12 +18362,15 @@ impl AnnotationPropertyDomain {
             "ap" => {
                 self.ap = value.extract()?;
                 Ok(())
-            },
+            }
             "iri" => {
                 self.iri = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -17153,9 +18384,10 @@ impl AnnotationPropertyDomain {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::AnnotationPropertyDomain<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::AnnotationPropertyDomain<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -17191,7 +18423,6 @@ impl From<&horned_owl::model::AnnotationPropertyDomain<ArcStr>> for AnnotationPr
     }
 }
 
-
 impl From<&AnnotationPropertyDomain> for horned_owl::model::AnnotationPropertyDomain<ArcStr> {
     fn from(value: &AnnotationPropertyDomain) -> Self {
         horned_owl::model::AnnotationPropertyDomain::<ArcStr> {
@@ -17201,28 +18432,34 @@ impl From<&AnnotationPropertyDomain> for horned_owl::model::AnnotationPropertyDo
     }
 }
 
-
-
 /**************** Base implementations for AnnotationPropertyDomain ****************/
-impl FromCompatible<horned_owl::model::AnnotationPropertyDomain<ArcStr>> for AnnotationPropertyDomain {
+impl FromCompatible<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+    for AnnotationPropertyDomain
+{
     fn from_c(value: horned_owl::model::AnnotationPropertyDomain<ArcStr>) -> Self {
         AnnotationPropertyDomain::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::AnnotationPropertyDomain<ArcStr>> for AnnotationPropertyDomain {
+impl FromCompatible<&horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+    for AnnotationPropertyDomain
+{
     fn from_c(value: &horned_owl::model::AnnotationPropertyDomain<ArcStr>) -> Self {
         AnnotationPropertyDomain::from(value)
     }
 }
 
-impl FromCompatible<AnnotationPropertyDomain> for horned_owl::model::AnnotationPropertyDomain<ArcStr> {
+impl FromCompatible<AnnotationPropertyDomain>
+    for horned_owl::model::AnnotationPropertyDomain<ArcStr>
+{
     fn from_c(value: AnnotationPropertyDomain) -> Self {
         horned_owl::model::AnnotationPropertyDomain::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&AnnotationPropertyDomain> for horned_owl::model::AnnotationPropertyDomain<ArcStr> {
+impl FromCompatible<&AnnotationPropertyDomain>
+    for horned_owl::model::AnnotationPropertyDomain<ArcStr>
+{
     fn from_c(value: &AnnotationPropertyDomain) -> Self {
         horned_owl::model::AnnotationPropertyDomain::<ArcStr>::from(value)
     }
@@ -17240,43 +18477,59 @@ impl From<AnnotationPropertyDomain> for horned_owl::model::AnnotationPropertyDom
     }
 }
 
-impl From<&BoxWrap<AnnotationPropertyDomain>> for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl From<&BoxWrap<AnnotationPropertyDomain>>
+    for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from(value: &BoxWrap<AnnotationPropertyDomain>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for BoxWrap<AnnotationPropertyDomain> {
+impl From<&Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for BoxWrap<AnnotationPropertyDomain>
+{
     fn from(value: &Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<AnnotationPropertyDomain>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<AnnotationPropertyDomain>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<AnnotationPropertyDomain>> for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl From<BoxWrap<AnnotationPropertyDomain>>
+    for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from(value: BoxWrap<AnnotationPropertyDomain>) -> Self {
         Into::<Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for BoxWrap<AnnotationPropertyDomain> {
+impl From<Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for BoxWrap<AnnotationPropertyDomain>
+{
     fn from(value: Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         Into::<BoxWrap<AnnotationPropertyDomain>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<AnnotationPropertyDomain>> for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl From<VecWrap<AnnotationPropertyDomain>>
+    for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from(value: VecWrap<AnnotationPropertyDomain>) -> Self {
         Into::<Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for VecWrap<AnnotationPropertyDomain> {
+impl From<Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for VecWrap<AnnotationPropertyDomain>
+{
     fn from(value: Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         Into::<VecWrap<AnnotationPropertyDomain>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<AnnotationPropertyDomain>> for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl From<&VecWrap<AnnotationPropertyDomain>>
+    for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from(value: &VecWrap<AnnotationPropertyDomain>) -> Self {
         value
             .0
@@ -17285,48 +18538,66 @@ impl From<&VecWrap<AnnotationPropertyDomain>> for Vec<horned_owl::model::Annotat
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for VecWrap<AnnotationPropertyDomain> {
+impl From<&Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for VecWrap<AnnotationPropertyDomain>
+{
     fn from(value: &Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         VecWrap(value.iter().map(AnnotationPropertyDomain::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<AnnotationPropertyDomain>> for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnnotationPropertyDomain>>
+    for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnnotationPropertyDomain>) -> Self {
         Box::<horned_owl::model::AnnotationPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for BoxWrap<AnnotationPropertyDomain> {
+impl FromCompatible<&Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for BoxWrap<AnnotationPropertyDomain>
+{
     fn from_c(value: &Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         BoxWrap::<AnnotationPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnnotationPropertyDomain>> for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl FromCompatible<BoxWrap<AnnotationPropertyDomain>>
+    for Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnnotationPropertyDomain>) -> Self {
         Box::<horned_owl::model::AnnotationPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for BoxWrap<AnnotationPropertyDomain> {
+impl FromCompatible<Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for BoxWrap<AnnotationPropertyDomain>
+{
     fn from_c(value: Box<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         BoxWrap::<AnnotationPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnnotationPropertyDomain>> for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl FromCompatible<VecWrap<AnnotationPropertyDomain>>
+    for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from_c(value: VecWrap<AnnotationPropertyDomain>) -> Self {
         Vec::<horned_owl::model::AnnotationPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for VecWrap<AnnotationPropertyDomain> {
+impl FromCompatible<Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for VecWrap<AnnotationPropertyDomain>
+{
     fn from_c(value: Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         VecWrap::<AnnotationPropertyDomain>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnnotationPropertyDomain>> for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>> {
+impl FromCompatible<&VecWrap<AnnotationPropertyDomain>>
+    for Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnnotationPropertyDomain>) -> Self {
         Vec::<horned_owl::model::AnnotationPropertyDomain<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> for VecWrap<AnnotationPropertyDomain> {
+impl FromCompatible<&Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>>
+    for VecWrap<AnnotationPropertyDomain>
+{
     fn from_c(value: &Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>) -> Self {
         VecWrap::<AnnotationPropertyDomain>::from(value)
     }
@@ -17335,41 +18606,38 @@ impl FromCompatible<&Vec<horned_owl::model::AnnotationPropertyDomain<ArcStr>>> f
     "\n\n",
     doc!(AnnotationPropertyRange)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnnotationPropertyRange {
-        #[doc="ap: AnnotationProperty"]
-        #[pyo3(get,set)]
-        pub ap: AnnotationProperty,
-    
-        #[doc="iri: IRI"]
-        #[pyo3(get,set)]
-        pub iri: IRI,
-    }
+    #[doc = "ap: AnnotationProperty"]
+    #[pyo3(get, set)]
+    pub ap: AnnotationProperty,
+
+    #[doc = "iri: IRI"]
+    #[pyo3(get, set)]
+    pub iri: IRI,
+}
 
 #[pymethods]
 impl AnnotationPropertyRange {
     #[new]
-    fn new(ap: AnnotationProperty,iri: IRI,) -> Self {
-        AnnotationPropertyRange {
-                ap,
-                iri,
-        }
+    fn new(ap: AnnotationProperty, iri: IRI) -> Self {
+        AnnotationPropertyRange { ap, iri }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "ap".to_string(),
-            "iri".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("ap".to_string(), "iri".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "ap" => self.ap.clone().into_pyobject(py).map(Bound::into_any),
             "iri" => self.iri.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -17378,12 +18646,15 @@ impl AnnotationPropertyRange {
             "ap" => {
                 self.ap = value.extract()?;
                 Ok(())
-            },
+            }
             "iri" => {
                 self.iri = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -17397,9 +18668,10 @@ impl AnnotationPropertyRange {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::AnnotationPropertyRange<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::AnnotationPropertyRange<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -17435,7 +18707,6 @@ impl From<&horned_owl::model::AnnotationPropertyRange<ArcStr>> for AnnotationPro
     }
 }
 
-
 impl From<&AnnotationPropertyRange> for horned_owl::model::AnnotationPropertyRange<ArcStr> {
     fn from(value: &AnnotationPropertyRange) -> Self {
         horned_owl::model::AnnotationPropertyRange::<ArcStr> {
@@ -17445,28 +18716,34 @@ impl From<&AnnotationPropertyRange> for horned_owl::model::AnnotationPropertyRan
     }
 }
 
-
-
 /**************** Base implementations for AnnotationPropertyRange ****************/
-impl FromCompatible<horned_owl::model::AnnotationPropertyRange<ArcStr>> for AnnotationPropertyRange {
+impl FromCompatible<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+    for AnnotationPropertyRange
+{
     fn from_c(value: horned_owl::model::AnnotationPropertyRange<ArcStr>) -> Self {
         AnnotationPropertyRange::from(value)
     }
 }
 
-impl FromCompatible<&horned_owl::model::AnnotationPropertyRange<ArcStr>> for AnnotationPropertyRange {
+impl FromCompatible<&horned_owl::model::AnnotationPropertyRange<ArcStr>>
+    for AnnotationPropertyRange
+{
     fn from_c(value: &horned_owl::model::AnnotationPropertyRange<ArcStr>) -> Self {
         AnnotationPropertyRange::from(value)
     }
 }
 
-impl FromCompatible<AnnotationPropertyRange> for horned_owl::model::AnnotationPropertyRange<ArcStr> {
+impl FromCompatible<AnnotationPropertyRange>
+    for horned_owl::model::AnnotationPropertyRange<ArcStr>
+{
     fn from_c(value: AnnotationPropertyRange) -> Self {
         horned_owl::model::AnnotationPropertyRange::<ArcStr>::from(value)
     }
 }
 
-impl FromCompatible<&AnnotationPropertyRange> for horned_owl::model::AnnotationPropertyRange<ArcStr> {
+impl FromCompatible<&AnnotationPropertyRange>
+    for horned_owl::model::AnnotationPropertyRange<ArcStr>
+{
     fn from_c(value: &AnnotationPropertyRange) -> Self {
         horned_owl::model::AnnotationPropertyRange::<ArcStr>::from(value)
     }
@@ -17484,43 +18761,59 @@ impl From<AnnotationPropertyRange> for horned_owl::model::AnnotationPropertyRang
     }
 }
 
-impl From<&BoxWrap<AnnotationPropertyRange>> for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl From<&BoxWrap<AnnotationPropertyRange>>
+    for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from(value: &BoxWrap<AnnotationPropertyRange>) -> Self {
         Box::new((*value.0.clone()).into())
     }
 }
 
-impl From<&Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for BoxWrap<AnnotationPropertyRange> {
+impl From<&Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for BoxWrap<AnnotationPropertyRange>
+{
     fn from(value: &Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
-        BoxWrap(Box::new(Into::<AnnotationPropertyRange>::into(*value.clone())))
+        BoxWrap(Box::new(Into::<AnnotationPropertyRange>::into(
+            *value.clone(),
+        )))
     }
 }
 
-impl From<BoxWrap<AnnotationPropertyRange>> for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl From<BoxWrap<AnnotationPropertyRange>>
+    for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from(value: BoxWrap<AnnotationPropertyRange>) -> Self {
         Into::<Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for BoxWrap<AnnotationPropertyRange> {
+impl From<Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for BoxWrap<AnnotationPropertyRange>
+{
     fn from(value: Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         Into::<BoxWrap<AnnotationPropertyRange>>::into(value.borrow())
     }
 }
 
-impl From<VecWrap<AnnotationPropertyRange>> for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl From<VecWrap<AnnotationPropertyRange>>
+    for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from(value: VecWrap<AnnotationPropertyRange>) -> Self {
         Into::<Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>>::into(value.borrow())
     }
 }
 
-impl From<Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for VecWrap<AnnotationPropertyRange> {
+impl From<Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for VecWrap<AnnotationPropertyRange>
+{
     fn from(value: Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         Into::<VecWrap<AnnotationPropertyRange>>::into(value.borrow())
     }
 }
 
-impl From<&VecWrap<AnnotationPropertyRange>> for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl From<&VecWrap<AnnotationPropertyRange>>
+    for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from(value: &VecWrap<AnnotationPropertyRange>) -> Self {
         value
             .0
@@ -17529,48 +18822,66 @@ impl From<&VecWrap<AnnotationPropertyRange>> for Vec<horned_owl::model::Annotati
             .collect()
     }
 }
-impl From<&Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for VecWrap<AnnotationPropertyRange> {
+impl From<&Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for VecWrap<AnnotationPropertyRange>
+{
     fn from(value: &Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         VecWrap(value.iter().map(AnnotationPropertyRange::from).collect())
     }
 }
 
-impl FromCompatible<&BoxWrap<AnnotationPropertyRange>> for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnnotationPropertyRange>>
+    for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnnotationPropertyRange>) -> Self {
         Box::<horned_owl::model::AnnotationPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for BoxWrap<AnnotationPropertyRange> {
+impl FromCompatible<&Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for BoxWrap<AnnotationPropertyRange>
+{
     fn from_c(value: &Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         BoxWrap::<AnnotationPropertyRange>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnnotationPropertyRange>> for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl FromCompatible<BoxWrap<AnnotationPropertyRange>>
+    for Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnnotationPropertyRange>) -> Self {
         Box::<horned_owl::model::AnnotationPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for BoxWrap<AnnotationPropertyRange> {
+impl FromCompatible<Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for BoxWrap<AnnotationPropertyRange>
+{
     fn from_c(value: Box<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         BoxWrap::<AnnotationPropertyRange>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnnotationPropertyRange>> for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl FromCompatible<VecWrap<AnnotationPropertyRange>>
+    for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from_c(value: VecWrap<AnnotationPropertyRange>) -> Self {
         Vec::<horned_owl::model::AnnotationPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for VecWrap<AnnotationPropertyRange> {
+impl FromCompatible<Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for VecWrap<AnnotationPropertyRange>
+{
     fn from_c(value: Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         VecWrap::<AnnotationPropertyRange>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnnotationPropertyRange>> for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>> {
+impl FromCompatible<&VecWrap<AnnotationPropertyRange>>
+    for Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnnotationPropertyRange>) -> Self {
         Vec::<horned_owl::model::AnnotationPropertyRange<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>> for VecWrap<AnnotationPropertyRange> {
+impl FromCompatible<&Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>>
+    for VecWrap<AnnotationPropertyRange>
+{
     fn from_c(value: &Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>) -> Self {
         VecWrap::<AnnotationPropertyRange>::from(value)
     }
@@ -17580,26 +18891,24 @@ impl FromCompatible<&Vec<horned_owl::model::AnnotationPropertyRange<ArcStr>>> fo
     "\n\n",
     doc!(DocIRI)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct DocIRI (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct DocIRI(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl DocIRI {
     #[new]
-    fn new(first: IRI,) -> Self {
-        DocIRI (first,)
+    fn new(first: IRI) -> Self {
+        DocIRI(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -17612,9 +18921,10 @@ impl DocIRI {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::DocIRI<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::DocIRI<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -17643,22 +18953,15 @@ impl DocIRI {
 
 impl From<&horned_owl::model::DocIRI<ArcStr>> for DocIRI {
     fn from(value: &horned_owl::model::DocIRI<ArcStr>) -> Self {
-
-        DocIRI (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        DocIRI(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&DocIRI> for horned_owl::model::DocIRI<ArcStr> {
     fn from(value: &DocIRI) -> Self {
-        horned_owl::model::DocIRI::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::DocIRI::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for DocIRI ****************/
 impl FromCompatible<horned_owl::model::DocIRI<ArcStr>> for DocIRI {
@@ -17792,41 +19095,38 @@ impl FromCompatible<&Vec<horned_owl::model::DocIRI<ArcStr>>> for VecWrap<DocIRI>
     "\n\n",
     doc!(OntologyID)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct OntologyID {
-        #[doc="iri: typing.Optional[IRI]"]
-        #[pyo3(get,set)]
-        pub iri: Option<IRI>,
-    
-        #[doc="viri: typing.Optional[IRI]"]
-        #[pyo3(get,set)]
-        pub viri: Option<IRI>,
-    }
+    #[doc = "iri: typing.Optional[IRI]"]
+    #[pyo3(get, set)]
+    pub iri: Option<IRI>,
+
+    #[doc = "viri: typing.Optional[IRI]"]
+    #[pyo3(get, set)]
+    pub viri: Option<IRI>,
+}
 
 #[pymethods]
 impl OntologyID {
     #[new]
-    fn new(iri: Option<IRI>,viri: Option<IRI>,) -> Self {
-        OntologyID {
-                iri,
-                viri,
-        }
+    fn new(iri: Option<IRI>, viri: Option<IRI>) -> Self {
+        OntologyID { iri, viri }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "iri".to_string(),
-            "viri".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("iri".to_string(), "viri".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "iri" => self.iri.clone().into_pyobject(py).map(Bound::into_any),
             "viri" => self.viri.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -17835,12 +19135,15 @@ impl OntologyID {
             "iri" => {
                 self.iri = value.extract()?;
                 Ok(())
-            },
+            }
             "viri" => {
                 self.viri = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -17854,9 +19157,10 @@ impl OntologyID {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::OntologyID<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::OntologyID<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -17892,7 +19196,6 @@ impl From<&horned_owl::model::OntologyID<ArcStr>> for OntologyID {
     }
 }
 
-
 impl From<&OntologyID> for horned_owl::model::OntologyID<ArcStr> {
     fn from(value: &OntologyID) -> Self {
         horned_owl::model::OntologyID::<ArcStr> {
@@ -17901,8 +19204,6 @@ impl From<&OntologyID> for horned_owl::model::OntologyID<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for OntologyID ****************/
 impl FromCompatible<horned_owl::model::OntologyID<ArcStr>> for OntologyID {
@@ -18037,26 +19338,24 @@ impl FromCompatible<&Vec<horned_owl::model::OntologyID<ArcStr>>> for VecWrap<Ont
     "\n\n",
     doc!(Variable)
 )]
-#[pyclass(module="pyhornedowl.model",from_py_object)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-pub struct Variable (
-    #[doc="first: "]
-    #[pyo3(get,set,name="first")]
+pub struct Variable(
+    #[doc = "first: "]
+    #[pyo3(get, set, name = "first")]
     pub IRI,
 );
 
 #[pymethods]
 impl Variable {
     #[new]
-    fn new(first: IRI,) -> Self {
-        Variable (first,)
+    fn new(first: IRI) -> Self {
+        Variable(first)
     }
 
     #[classattr]
     fn __match_args__() -> PyResult<(String,)> {
-        Ok((
-            "first".to_string(),
-        ))
+        Ok(("first".to_string(),))
     }
 
     fn __hash__(&self) -> u64 {
@@ -18069,9 +19368,10 @@ impl Variable {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::Variable<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::Variable<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -18095,22 +19395,15 @@ impl Variable {
 
 impl From<&horned_owl::model::Variable<ArcStr>> for Variable {
     fn from(value: &horned_owl::model::Variable<ArcStr>) -> Self {
-
-        Variable (
-    IntoCompatible::<IRI>::into_c(&value.0),
-        )
+        Variable(IntoCompatible::<IRI>::into_c(&value.0))
     }
 }
 
 impl From<&Variable> for horned_owl::model::Variable<ArcStr> {
     fn from(value: &Variable) -> Self {
-        horned_owl::model::Variable::<ArcStr> (
-    IntoCompatible::into_c(&value.0),
-        )
+        horned_owl::model::Variable::<ArcStr>(IntoCompatible::into_c(&value.0))
     }
 }
-
-
 
 /**************** Base implementations for Variable ****************/
 impl FromCompatible<horned_owl::model::Variable<ArcStr>> for Variable {
@@ -18242,13 +19535,11 @@ impl FromCompatible<&Vec<horned_owl::model::Variable<ArcStr>>> for VecWrap<Varia
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum DArgument {
-    
-        #[pyo3(transparent)]
-        Literal (Literal),
-    
-        #[pyo3(transparent)]
-        Variable (Variable),
-    
+    #[pyo3(transparent)]
+    Literal(Literal),
+
+    #[pyo3(transparent)]
+    Variable(Variable),
 }
 
 impl<'py> IntoPyObject<'py> for DArgument {
@@ -18258,11 +19549,9 @@ impl<'py> IntoPyObject<'py> for DArgument {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
             DArgument::Literal(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             DArgument::Variable(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
         }
     }
 }
@@ -18270,36 +19559,28 @@ impl<'py> IntoPyObject<'py> for DArgument {
 impl From<&DArgument> for horned_owl::model::DArgument<ArcStr> {
     fn from(value: &DArgument) -> Self {
         match value {
-        
             DArgument::Literal(inner) => horned_owl::model::DArgument::Literal(inner.into()),
-        
+
             DArgument::Variable(inner) => horned_owl::model::DArgument::Variable(inner.into()),
-        
         }
     }
 }
 
 impl From<&horned_owl::model::DArgument<ArcStr>> for DArgument {
-
     fn from(value: &horned_owl::model::DArgument<ArcStr>) -> Self {
         match value {
-        
             horned_owl::model::DArgument::Literal(inner) => DArgument::Literal(inner.into()),
-        
+
             horned_owl::model::DArgument::Variable(inner) => DArgument::Variable(inner.into()),
-        
         }
     }
 }
-
 
 impl DArgument {
     pub fn py_def() -> String {
         "typing.Union[m.Literal,m.Variable,]".into()
     }
 }
-
-
 
 /**************** Base implementations for DArgument ****************/
 impl FromCompatible<horned_owl::model::DArgument<ArcStr>> for DArgument {
@@ -18431,13 +19712,11 @@ impl FromCompatible<&Vec<horned_owl::model::DArgument<ArcStr>>> for VecWrap<DArg
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum IArgument {
-    
-        #[pyo3(transparent)]
-        Individual (Individual),
-    
-        #[pyo3(transparent)]
-        Variable (Variable),
-    
+    #[pyo3(transparent)]
+    Individual(Individual),
+
+    #[pyo3(transparent)]
+    Variable(Variable),
 }
 
 impl<'py> IntoPyObject<'py> for IArgument {
@@ -18447,11 +19726,9 @@ impl<'py> IntoPyObject<'py> for IArgument {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
             IArgument::Individual(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             IArgument::Variable(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
         }
     }
 }
@@ -18459,36 +19736,28 @@ impl<'py> IntoPyObject<'py> for IArgument {
 impl From<&IArgument> for horned_owl::model::IArgument<ArcStr> {
     fn from(value: &IArgument) -> Self {
         match value {
-        
             IArgument::Individual(inner) => horned_owl::model::IArgument::Individual(inner.into()),
-        
+
             IArgument::Variable(inner) => horned_owl::model::IArgument::Variable(inner.into()),
-        
         }
     }
 }
 
 impl From<&horned_owl::model::IArgument<ArcStr>> for IArgument {
-
     fn from(value: &horned_owl::model::IArgument<ArcStr>) -> Self {
         match value {
-        
             horned_owl::model::IArgument::Individual(inner) => IArgument::Individual(inner.into()),
-        
+
             horned_owl::model::IArgument::Variable(inner) => IArgument::Variable(inner.into()),
-        
         }
     }
 }
-
 
 impl IArgument {
     pub fn py_def() -> String {
         "typing.Union[m.Individual,m.Variable,]".into()
     }
 }
-
-
 
 /**************** Base implementations for IArgument ****************/
 impl FromCompatible<horned_owl::model::IArgument<ArcStr>> for IArgument {
@@ -18623,95 +19892,106 @@ impl FromCompatible<&Vec<horned_owl::model::IArgument<ArcStr>>> for VecWrap<IArg
 #[allow(clippy::enum_variant_names)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 enum Atom_Inner {
-	BuiltInAtom(BuiltInAtom),
-	ClassAtom(ClassAtom),
-	DataPropertyAtom(DataPropertyAtom),
-	DataRangeAtom(DataRangeAtom),
-	DifferentIndividualsAtom(DifferentIndividualsAtom),
-	ObjectPropertyAtom(ObjectPropertyAtom),
-	SameIndividualAtom(SameIndividualAtom),
+    BuiltInAtom(BuiltInAtom),
+    ClassAtom(ClassAtom),
+    DataPropertyAtom(DataPropertyAtom),
+    DataRangeAtom(DataRangeAtom),
+    DifferentIndividualsAtom(DifferentIndividualsAtom),
+    ObjectPropertyAtom(ObjectPropertyAtom),
+    SameIndividualAtom(SameIndividualAtom),
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Atom(Atom_Inner);
 
-
 /**************** ENUM VARIANTS for Atom ****************/
 
-    /**************** ENUM VARIANT BuiltInAtom for Atom ****************/
-    #[doc = concat!("BuiltInAtom(pred: IRIargs: typing.List[DArgument]",
+/**************** ENUM VARIANT BuiltInAtom for Atom ****************/
+#[doc = concat!("BuiltInAtom(pred: IRIargs: typing.List[DArgument]",
         "\n\n",doc!(BuiltInAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct BuiltInAtom{
-        #[doc="pred: IRI"]
-        #[pyo3(get,set)]
-        pub pred: IRI,
-        #[doc="args: typing.List[DArgument]"]
-        #[pyo3(get,set)]
-        pub args: VecWrap<DArgument>,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct BuiltInAtom {
+    #[doc = "pred: IRI"]
+    #[pyo3(get, set)]
+    pub pred: IRI,
+    #[doc = "args: typing.List[DArgument]"]
+    #[pyo3(get, set)]
+    pub args: VecWrap<DArgument>,
+}
 
-    impl From<BuiltInAtom> for Atom {
-        fn from(value: BuiltInAtom) -> Self {
-            Atom(Atom_Inner::BuiltInAtom(value))
+impl From<BuiltInAtom> for Atom {
+    fn from(value: BuiltInAtom) -> Self {
+        Atom(Atom_Inner::BuiltInAtom(value))
+    }
+}
+
+#[pymethods]
+impl BuiltInAtom {
+    #[new]
+    fn new(pred: IRI, args: VecWrap<DArgument>) -> Self {
+        BuiltInAtom { pred, args }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("pred".to_string(), "args".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "pred" => self
+                .pred
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "args" => self
+                .args
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl BuiltInAtom {
-        #[new]
-        fn new(pred: IRI,args: VecWrap<DArgument>,) -> Self {
-            BuiltInAtom{
-                pred,
-                args,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"pred".to_string(),
-            	"args".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"pred" => self.pred.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"args" => self.args.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"pred" => {
-                    self.pred = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "pred" => {
+                self.pred = value.extract()?;
                 Ok(())
-                },
-            	"args" => {
-                    self.args = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "args" => {
+                self.args = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -18731,85 +20011,94 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT ClassAtom for Atom ****************/
-    #[doc = concat!("ClassAtom(pred: ClassExpressionarg: IArgument",
+/**************** ENUM VARIANT ClassAtom for Atom ****************/
+#[doc = concat!("ClassAtom(pred: ClassExpressionarg: IArgument",
         "\n\n",doc!(ClassAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ClassAtom{
-        #[doc="pred: ClassExpression"]
-        #[pyo3(get,set)]
-        pub pred: ClassExpression,
-        #[doc="arg: IArgument"]
-        #[pyo3(get,set)]
-        pub arg: IArgument,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ClassAtom {
+    #[doc = "pred: ClassExpression"]
+    #[pyo3(get, set)]
+    pub pred: ClassExpression,
+    #[doc = "arg: IArgument"]
+    #[pyo3(get, set)]
+    pub arg: IArgument,
+}
 
-    impl From<ClassAtom> for Atom {
-        fn from(value: ClassAtom) -> Self {
-            Atom(Atom_Inner::ClassAtom(value))
+impl From<ClassAtom> for Atom {
+    fn from(value: ClassAtom) -> Self {
+        Atom(Atom_Inner::ClassAtom(value))
+    }
+}
+
+#[pymethods]
+impl ClassAtom {
+    #[new]
+    fn new(pred: ClassExpression, arg: IArgument) -> Self {
+        ClassAtom { pred, arg }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("pred".to_string(), "arg".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "pred" => self
+                .pred
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "arg" => self
+                .arg
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ClassAtom {
-        #[new]
-        fn new(pred: ClassExpression,arg: IArgument,) -> Self {
-            ClassAtom{
-                pred,
-                arg,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"pred".to_string(),
-            	"arg".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"pred" => self.pred.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"arg" => self.arg.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"pred" => {
-                    self.pred = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "pred" => {
+                self.pred = value.extract()?;
                 Ok(())
-                },
-            	"arg" => {
-                    self.arg = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "arg" => {
+                self.arg = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -18829,85 +20118,94 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DataPropertyAtom for Atom ****************/
-    #[doc = concat!("DataPropertyAtom(pred: DataPropertyargs: typing.Tuple[DArgument,DArgument]",
+/**************** ENUM VARIANT DataPropertyAtom for Atom ****************/
+#[doc = concat!("DataPropertyAtom(pred: DataPropertyargs: typing.Tuple[DArgument,DArgument]",
         "\n\n",doc!(DataPropertyAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataPropertyAtom{
-        #[doc="pred: DataProperty"]
-        #[pyo3(get,set)]
-        pub pred: DataProperty,
-        #[doc="args: typing.Tuple[DArgument,DArgument]"]
-        #[pyo3(get,set)]
-        pub args: (DArgument,DArgument),}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataPropertyAtom {
+    #[doc = "pred: DataProperty"]
+    #[pyo3(get, set)]
+    pub pred: DataProperty,
+    #[doc = "args: typing.Tuple[DArgument,DArgument]"]
+    #[pyo3(get, set)]
+    pub args: (DArgument, DArgument),
+}
 
-    impl From<DataPropertyAtom> for Atom {
-        fn from(value: DataPropertyAtom) -> Self {
-            Atom(Atom_Inner::DataPropertyAtom(value))
+impl From<DataPropertyAtom> for Atom {
+    fn from(value: DataPropertyAtom) -> Self {
+        Atom(Atom_Inner::DataPropertyAtom(value))
+    }
+}
+
+#[pymethods]
+impl DataPropertyAtom {
+    #[new]
+    fn new(pred: DataProperty, args: (DArgument, DArgument)) -> Self {
+        DataPropertyAtom { pred, args }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("pred".to_string(), "args".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "pred" => self
+                .pred
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "args" => self
+                .args
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataPropertyAtom {
-        #[new]
-        fn new(pred: DataProperty,args: (DArgument,DArgument),) -> Self {
-            DataPropertyAtom{
-                pred,
-                args,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"pred".to_string(),
-            	"args".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"pred" => self.pred.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"args" => self.args.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"pred" => {
-                    self.pred = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "pred" => {
+                self.pred = value.extract()?;
                 Ok(())
-                },
-            	"args" => {
-                    self.args = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "args" => {
+                self.args = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -18927,85 +20225,94 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DataRangeAtom for Atom ****************/
-    #[doc = concat!("DataRangeAtom(pred: DataRangearg: DArgument",
+/**************** ENUM VARIANT DataRangeAtom for Atom ****************/
+#[doc = concat!("DataRangeAtom(pred: DataRangearg: DArgument",
         "\n\n",doc!(DataRangeAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DataRangeAtom{
-        #[doc="pred: DataRange"]
-        #[pyo3(get,set)]
-        pub pred: DataRange,
-        #[doc="arg: DArgument"]
-        #[pyo3(get,set)]
-        pub arg: DArgument,}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DataRangeAtom {
+    #[doc = "pred: DataRange"]
+    #[pyo3(get, set)]
+    pub pred: DataRange,
+    #[doc = "arg: DArgument"]
+    #[pyo3(get, set)]
+    pub arg: DArgument,
+}
 
-    impl From<DataRangeAtom> for Atom {
-        fn from(value: DataRangeAtom) -> Self {
-            Atom(Atom_Inner::DataRangeAtom(value))
+impl From<DataRangeAtom> for Atom {
+    fn from(value: DataRangeAtom) -> Self {
+        Atom(Atom_Inner::DataRangeAtom(value))
+    }
+}
+
+#[pymethods]
+impl DataRangeAtom {
+    #[new]
+    fn new(pred: DataRange, arg: DArgument) -> Self {
+        DataRangeAtom { pred, arg }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("pred".to_string(), "arg".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "pred" => self
+                .pred
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "arg" => self
+                .arg
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DataRangeAtom {
-        #[new]
-        fn new(pred: DataRange,arg: DArgument,) -> Self {
-            DataRangeAtom{
-                pred,
-                arg,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"pred".to_string(),
-            	"arg".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"pred" => self.pred.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"arg" => self.arg.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"pred" => {
-                    self.pred = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "pred" => {
+                self.pred = value.extract()?;
                 Ok(())
-                },
-            	"arg" => {
-                    self.arg = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "arg" => {
+                self.arg = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -19025,85 +20332,90 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT DifferentIndividualsAtom for Atom ****************/
-    #[doc = concat!("DifferentIndividualsAtom(first: IArgumentsecond: IArgument",
+/**************** ENUM VARIANT DifferentIndividualsAtom for Atom ****************/
+#[doc = concat!("DifferentIndividualsAtom(first: IArgumentsecond: IArgument",
         "\n\n",doc!(DifferentIndividualsAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct DifferentIndividualsAtom(
-        #[pyo3(get,set,name="first")]
-        pub IArgument,
-        #[pyo3(get,set,name="second")]
-        pub IArgument,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct DifferentIndividualsAtom(
+    #[pyo3(get, set, name = "first")] pub IArgument,
+    #[pyo3(get, set, name = "second")] pub IArgument,
+);
 
-    impl From<DifferentIndividualsAtom> for Atom {
-        fn from(value: DifferentIndividualsAtom) -> Self {
-            Atom(Atom_Inner::DifferentIndividualsAtom(value))
+impl From<DifferentIndividualsAtom> for Atom {
+    fn from(value: DifferentIndividualsAtom) -> Self {
+        Atom(Atom_Inner::DifferentIndividualsAtom(value))
+    }
+}
+
+#[pymethods]
+impl DifferentIndividualsAtom {
+    #[new]
+    fn new(first: IArgument, second: IArgument) -> Self {
+        DifferentIndividualsAtom(first, second)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("first".to_string(), "second".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "second" => self
+                .1
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl DifferentIndividualsAtom {
-        #[new]
-        fn new(first: IArgument,second: IArgument,) -> Self {
-            DifferentIndividualsAtom(
-                first,
-                second,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"first".to_string(),
-            	"second".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"second" => self.1.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-            	"second" => {
-                    self.1 = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "second" => {
+                self.1 = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -19123,85 +20435,94 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT ObjectPropertyAtom for Atom ****************/
-    #[doc = concat!("ObjectPropertyAtom(pred: ObjectPropertyExpressionargs: typing.Tuple[IArgument,IArgument]",
+/**************** ENUM VARIANT ObjectPropertyAtom for Atom ****************/
+#[doc = concat!("ObjectPropertyAtom(pred: ObjectPropertyExpressionargs: typing.Tuple[IArgument,IArgument]",
         "\n\n",doc!(ObjectPropertyAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct ObjectPropertyAtom{
-        #[doc="pred: ObjectPropertyExpression"]
-        #[pyo3(get,set)]
-        pub pred: ObjectPropertyExpression,
-        #[doc="args: typing.Tuple[IArgument,IArgument]"]
-        #[pyo3(get,set)]
-        pub args: (IArgument,IArgument),}
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct ObjectPropertyAtom {
+    #[doc = "pred: ObjectPropertyExpression"]
+    #[pyo3(get, set)]
+    pub pred: ObjectPropertyExpression,
+    #[doc = "args: typing.Tuple[IArgument,IArgument]"]
+    #[pyo3(get, set)]
+    pub args: (IArgument, IArgument),
+}
 
-    impl From<ObjectPropertyAtom> for Atom {
-        fn from(value: ObjectPropertyAtom) -> Self {
-            Atom(Atom_Inner::ObjectPropertyAtom(value))
+impl From<ObjectPropertyAtom> for Atom {
+    fn from(value: ObjectPropertyAtom) -> Self {
+        Atom(Atom_Inner::ObjectPropertyAtom(value))
+    }
+}
+
+#[pymethods]
+impl ObjectPropertyAtom {
+    #[new]
+    fn new(pred: ObjectPropertyExpression, args: (IArgument, IArgument)) -> Self {
+        ObjectPropertyAtom { pred, args }
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("pred".to_string(), "args".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "pred" => self
+                .pred
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "args" => self
+                .args
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl ObjectPropertyAtom {
-        #[new]
-        fn new(pred: ObjectPropertyExpression,args: (IArgument,IArgument),) -> Self {
-            ObjectPropertyAtom{
-                pred,
-                args,}
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"pred".to_string(),
-            	"args".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"pred" => self.pred.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"args" => self.args.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"pred" => {
-                    self.pred = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "pred" => {
+                self.pred = value.extract()?;
                 Ok(())
-                },
-            	"args" => {
-                    self.args = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "args" => {
+                self.args = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -19221,85 +20542,90 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
+}
 
-    
-
-
-    /**************** ENUM VARIANT SameIndividualAtom for Atom ****************/
-    #[doc = concat!("SameIndividualAtom(first: IArgumentsecond: IArgument",
+/**************** ENUM VARIANT SameIndividualAtom for Atom ****************/
+#[doc = concat!("SameIndividualAtom(first: IArgumentsecond: IArgument",
         "\n\n",doc!(SameIndividualAtom))]
-    #[allow(non_camel_case_types)]
-    #[pyclass(module="pyhornedowl.model",from_py_object)]
-    #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
-    pub struct SameIndividualAtom(
-        #[pyo3(get,set,name="first")]
-        pub IArgument,
-        #[pyo3(get,set,name="second")]
-        pub IArgument,
-    );
+#[allow(non_camel_case_types)]
+#[pyclass(module = "pyhornedowl.model", from_py_object)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct SameIndividualAtom(
+    #[pyo3(get, set, name = "first")] pub IArgument,
+    #[pyo3(get, set, name = "second")] pub IArgument,
+);
 
-    impl From<SameIndividualAtom> for Atom {
-        fn from(value: SameIndividualAtom) -> Self {
-            Atom(Atom_Inner::SameIndividualAtom(value))
+impl From<SameIndividualAtom> for Atom {
+    fn from(value: SameIndividualAtom) -> Self {
+        Atom(Atom_Inner::SameIndividualAtom(value))
+    }
+}
+
+#[pymethods]
+impl SameIndividualAtom {
+    #[new]
+    fn new(first: IArgument, second: IArgument) -> Self {
+        SameIndividualAtom(first, second)
+    }
+
+    #[classattr]
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("first".to_string(), "second".to_string()))
+    }
+
+    fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
+        match name {
+            "first" => self
+                .0
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            "second" => self
+                .1
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any)
+                .map_err(PyErr::from),
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
-    #[pymethods]
-    impl SameIndividualAtom {
-        #[new]
-        fn new(first: IArgument,second: IArgument,) -> Self {
-            SameIndividualAtom(
-                first,
-                second,
-            )
-        }
-
-        #[classattr]
-        fn __match_args__() -> PyResult<(String, String,)> {
-            Ok((
-            	"first".to_string(),
-            	"second".to_string(),
-            ))
-        }
-
-
-        fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
-            match name {
-            	"first" => self.0.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-            	"second" => self.1.clone().into_pyobject(py).map(Bound::into_any).map_err(PyErr::from),
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
-            }
-        }
-
-        fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
-            match name {
-            	"first" => {
-                    self.0 = value.extract()?;
+    fn __setitem__(&mut self, name: &str, value: &Bound<'_, PyAny>) -> PyResult<()> {
+        match name {
+            "first" => {
+                self.0 = value.extract()?;
                 Ok(())
-                },
-            	"second" => {
-                    self.1 = value.extract()?;
-                Ok(())
-                },
-                &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
             }
+            "second" => {
+                self.1 = value.extract()?;
+                Ok(())
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
+    }
 
-        fn __hash__(&self) -> u64 {
-            let mut s = DefaultHasher::new();
-            Hash::hash(&self, &mut s);
-            s.finish()
-        }
+    fn __hash__(&self) -> u64 {
+        let mut s = DefaultHasher::new();
+        Hash::hash(&self, &mut s);
+        s.finish()
+    }
 
-        fn __eq__(&self, other: &Self) -> bool {
-            self == other
-        }
+    fn __eq__(&self, other: &Self) -> bool {
+        self == other
+    }
 
-        fn __str__(&self) -> String {
-            Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone())).as_functional().to_string()
-        }
-
+    fn __str__(&self) -> String {
+        Into::<horned_owl::model::Atom<ArcStr>>::into(Into::<Atom>::into(self.clone()))
+            .as_functional()
+            .to_string()
+    }
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -19319,34 +20645,49 @@ pub struct Atom(Atom_Inner);
             crate::snippet::SnippetSyntax::Functional => crate::as_ofn!(value, prefix_mapping),
         })
     }
-    }
-
-    
-
-
+}
 
 impl From<&horned_owl::model::Atom<ArcStr>> for Atom {
     fn from(value: &horned_owl::model::Atom<ArcStr>) -> Self {
-        match value {horned_owl::model::Atom::BuiltInAtom::<ArcStr>{
-                    pred,
-args
-                } => Atom(Atom_Inner::BuiltInAtom(BuiltInAtom{pred: IntoCompatible::<IRI>::into_c(pred),args: IntoCompatible::<VecWrap<DArgument>>::into_c(args),})),horned_owl::model::Atom::ClassAtom::<ArcStr>{
-                    pred,
-arg
-                } => Atom(Atom_Inner::ClassAtom(ClassAtom{pred: IntoCompatible::<ClassExpression>::into_c(pred),arg: IntoCompatible::<IArgument>::into_c(arg),})),horned_owl::model::Atom::DataPropertyAtom::<ArcStr>{
-                    pred,
-args
-                } => Atom(Atom_Inner::DataPropertyAtom(DataPropertyAtom{pred: IntoCompatible::<DataProperty>::into_c(pred),args: IntoCompatible::<(DArgument,DArgument)>::into_c(args),})),horned_owl::model::Atom::DataRangeAtom::<ArcStr>{
-                    pred,
-arg
-                } => Atom(Atom_Inner::DataRangeAtom(DataRangeAtom{pred: IntoCompatible::<DataRange>::into_c(pred),arg: IntoCompatible::<DArgument>::into_c(arg),})),
-                horned_owl::model::Atom::DifferentIndividualsAtom::<ArcStr>(first, second) =>
-                    Atom(Atom_Inner::DifferentIndividualsAtom(DifferentIndividualsAtom((first).into(),(second).into(),))),horned_owl::model::Atom::ObjectPropertyAtom::<ArcStr>{
-                    pred,
-args
-                } => Atom(Atom_Inner::ObjectPropertyAtom(ObjectPropertyAtom{pred: IntoCompatible::<ObjectPropertyExpression>::into_c(pred),args: IntoCompatible::<(IArgument,IArgument)>::into_c(args),})),
-                horned_owl::model::Atom::SameIndividualAtom::<ArcStr>(first, second) =>
-                    Atom(Atom_Inner::SameIndividualAtom(SameIndividualAtom((first).into(),(second).into(),))),
+        match value {
+            horned_owl::model::Atom::BuiltInAtom::<ArcStr> { pred, args } => {
+                Atom(Atom_Inner::BuiltInAtom(BuiltInAtom {
+                    pred: IntoCompatible::<IRI>::into_c(pred),
+                    args: IntoCompatible::<VecWrap<DArgument>>::into_c(args),
+                }))
+            }
+            horned_owl::model::Atom::ClassAtom::<ArcStr> { pred, arg } => {
+                Atom(Atom_Inner::ClassAtom(ClassAtom {
+                    pred: IntoCompatible::<ClassExpression>::into_c(pred),
+                    arg: IntoCompatible::<IArgument>::into_c(arg),
+                }))
+            }
+            horned_owl::model::Atom::DataPropertyAtom::<ArcStr> { pred, args } => {
+                Atom(Atom_Inner::DataPropertyAtom(DataPropertyAtom {
+                    pred: IntoCompatible::<DataProperty>::into_c(pred),
+                    args: IntoCompatible::<(DArgument, DArgument)>::into_c(args),
+                }))
+            }
+            horned_owl::model::Atom::DataRangeAtom::<ArcStr> { pred, arg } => {
+                Atom(Atom_Inner::DataRangeAtom(DataRangeAtom {
+                    pred: IntoCompatible::<DataRange>::into_c(pred),
+                    arg: IntoCompatible::<DArgument>::into_c(arg),
+                }))
+            }
+            horned_owl::model::Atom::DifferentIndividualsAtom::<ArcStr>(first, second) => {
+                Atom(Atom_Inner::DifferentIndividualsAtom(
+                    DifferentIndividualsAtom((first).into(), (second).into()),
+                ))
+            }
+            horned_owl::model::Atom::ObjectPropertyAtom::<ArcStr> { pred, args } => {
+                Atom(Atom_Inner::ObjectPropertyAtom(ObjectPropertyAtom {
+                    pred: IntoCompatible::<ObjectPropertyExpression>::into_c(pred),
+                    args: IntoCompatible::<(IArgument, IArgument)>::into_c(args),
+                }))
+            }
+            horned_owl::model::Atom::SameIndividualAtom::<ArcStr>(first, second) => Atom(
+                Atom_Inner::SameIndividualAtom(SameIndividualAtom((first).into(), (second).into())),
+            ),
         }
     }
 }
@@ -19354,46 +20695,48 @@ args
 impl From<&Atom> for horned_owl::model::Atom<ArcStr> {
     fn from(value: &Atom) -> Self {
         match value.0.borrow() {
-                Atom_Inner::BuiltInAtom(BuiltInAtom{
-                    pred, args
-                }) => horned_owl::model::Atom::<ArcStr>::BuiltInAtom{
-                	pred: pred.into_c(),
-                	args: args.into_c(),
-                },
-                Atom_Inner::ClassAtom(ClassAtom{
-                    pred, arg
-                }) => horned_owl::model::Atom::<ArcStr>::ClassAtom{
-                	pred: pred.into_c(),
-                	arg: arg.into_c(),
-                },
-                Atom_Inner::DataPropertyAtom(DataPropertyAtom{
-                    pred, args
-                }) => horned_owl::model::Atom::<ArcStr>::DataPropertyAtom{
-                	pred: pred.into_c(),
-                	args: args.into_c(),
-                },
-                Atom_Inner::DataRangeAtom(DataRangeAtom{
-                    pred, arg
-                }) => horned_owl::model::Atom::<ArcStr>::DataRangeAtom{
-                	pred: pred.into_c(),
-                	arg: arg.into_c(),
-                },
-                Atom_Inner::DifferentIndividualsAtom(DifferentIndividualsAtom(first, second)) =>
+            Atom_Inner::BuiltInAtom(BuiltInAtom { pred, args }) => {
+                horned_owl::model::Atom::<ArcStr>::BuiltInAtom {
+                    pred: pred.into_c(),
+                    args: args.into_c(),
+                }
+            }
+            Atom_Inner::ClassAtom(ClassAtom { pred, arg }) => {
+                horned_owl::model::Atom::<ArcStr>::ClassAtom {
+                    pred: pred.into_c(),
+                    arg: arg.into_c(),
+                }
+            }
+            Atom_Inner::DataPropertyAtom(DataPropertyAtom { pred, args }) => {
+                horned_owl::model::Atom::<ArcStr>::DataPropertyAtom {
+                    pred: pred.into_c(),
+                    args: args.into_c(),
+                }
+            }
+            Atom_Inner::DataRangeAtom(DataRangeAtom { pred, arg }) => {
+                horned_owl::model::Atom::<ArcStr>::DataRangeAtom {
+                    pred: pred.into_c(),
+                    arg: arg.into_c(),
+                }
+            }
+            Atom_Inner::DifferentIndividualsAtom(DifferentIndividualsAtom(first, second)) => {
                 horned_owl::model::Atom::<ArcStr>::DifferentIndividualsAtom(
                     first.into_c(),
                     second.into_c(),
-                ),
-                Atom_Inner::ObjectPropertyAtom(ObjectPropertyAtom{
-                    pred, args
-                }) => horned_owl::model::Atom::<ArcStr>::ObjectPropertyAtom{
-                	pred: pred.into_c(),
-                	args: args.into_c(),
-                },
-                Atom_Inner::SameIndividualAtom(SameIndividualAtom(first, second)) =>
+                )
+            }
+            Atom_Inner::ObjectPropertyAtom(ObjectPropertyAtom { pred, args }) => {
+                horned_owl::model::Atom::<ArcStr>::ObjectPropertyAtom {
+                    pred: pred.into_c(),
+                    args: args.into_c(),
+                }
+            }
+            Atom_Inner::SameIndividualAtom(SameIndividualAtom(first, second)) => {
                 horned_owl::model::Atom::<ArcStr>::SameIndividualAtom(
                     first.into_c(),
                     second.into_c(),
-                ),
+                )
+            }
         }
     }
 }
@@ -19405,95 +20748,80 @@ impl<'py> IntoPyObject<'py> for Atom {
 
     fn into_pyobject(self, py: pyo3::Python<'py>) -> Result<Self::Output, Self::Error> {
         match self.0 {
-            
-                Atom_Inner::BuiltInAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Atom_Inner::ClassAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Atom_Inner::DataPropertyAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Atom_Inner::DataRangeAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Atom_Inner::DifferentIndividualsAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Atom_Inner::ObjectPropertyAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
-                Atom_Inner::SameIndividualAtom(val) => {
-                    val.into_pyobject(py).map(Bound::into_any)
-                },
-            
+            Atom_Inner::BuiltInAtom(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Atom_Inner::ClassAtom(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Atom_Inner::DataPropertyAtom(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Atom_Inner::DataRangeAtom(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Atom_Inner::DifferentIndividualsAtom(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Atom_Inner::ObjectPropertyAtom(val) => val.into_pyobject(py).map(Bound::into_any),
+
+            Atom_Inner::SameIndividualAtom(val) => val.into_pyobject(py).map(Bound::into_any),
         }
     }
-
 }
 
-impl <'py> FromPyObject<'_, 'py> for Atom {
+impl<'py> FromPyObject<'_, 'py> for Atom {
     type Error = PyErr;
 
     fn extract(ob: Borrowed<'_, 'py, PyAny>) -> Result<Self, Self::Error> {
-            {
-                let r = BuiltInAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::BuiltInAtom(local);
-                    return Ok(Atom(inner));
-                }
+        {
+            let r = BuiltInAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::BuiltInAtom(local);
+                return Ok(Atom(inner));
             }
-            {
-                let r = ClassAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::ClassAtom(local);
-                    return Ok(Atom(inner));
-                }
+        }
+        {
+            let r = ClassAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::ClassAtom(local);
+                return Ok(Atom(inner));
             }
-            {
-                let r = DataPropertyAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::DataPropertyAtom(local);
-                    return Ok(Atom(inner));
-                }
+        }
+        {
+            let r = DataPropertyAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::DataPropertyAtom(local);
+                return Ok(Atom(inner));
             }
-            {
-                let r = DataRangeAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::DataRangeAtom(local);
-                    return Ok(Atom(inner));
-                }
+        }
+        {
+            let r = DataRangeAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::DataRangeAtom(local);
+                return Ok(Atom(inner));
             }
-            {
-                let r = DifferentIndividualsAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::DifferentIndividualsAtom(local);
-                    return Ok(Atom(inner));
-                }
+        }
+        {
+            let r = DifferentIndividualsAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::DifferentIndividualsAtom(local);
+                return Ok(Atom(inner));
             }
-            {
-                let r = ObjectPropertyAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::ObjectPropertyAtom(local);
-                    return Ok(Atom(inner));
-                }
+        }
+        {
+            let r = ObjectPropertyAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::ObjectPropertyAtom(local);
+                return Ok(Atom(inner));
             }
-            {
-                let r = SameIndividualAtom::extract(ob);
-                if let Ok(local) = r {
-                    let inner = Atom_Inner::SameIndividualAtom(local);
-                    return Ok(Atom(inner));
-                }
+        }
+        {
+            let r = SameIndividualAtom::extract(ob);
+            if let Ok(local) = r {
+                let inner = Atom_Inner::SameIndividualAtom(local);
+                return Ok(Atom(inner));
             }
+        }
 
-        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>("Object cannot be converted to Atom"))
+        Err(pyo3::PyErr::new::<pyo3::exceptions::PyTypeError, _>(
+            "Object cannot be converted to Atom",
+        ))
     }
 }
 
@@ -19502,8 +20830,6 @@ impl Atom {
         "typing.Union[m.BuiltInAtom,m.ClassAtom,m.DataPropertyAtom,m.DataRangeAtom,m.DifferentIndividualsAtom,m.ObjectPropertyAtom,m.SameIndividualAtom,]".into()
     }
 }
-
-
 
 /**************** Base implementations for Atom ****************/
 impl FromCompatible<horned_owl::model::Atom<ArcStr>> for Atom {
@@ -19637,41 +20963,38 @@ impl FromCompatible<&Vec<horned_owl::model::Atom<ArcStr>>> for VecWrap<Atom> {
     "\n\n",
     doc!(Rule)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Rule {
-        #[doc="head: typing.List[Atom]"]
-        #[pyo3(get,set)]
-        pub head: VecWrap<Atom>,
-    
-        #[doc="body: typing.List[Atom]"]
-        #[pyo3(get,set)]
-        pub body: VecWrap<Atom>,
-    }
+    #[doc = "head: typing.List[Atom]"]
+    #[pyo3(get, set)]
+    pub head: VecWrap<Atom>,
+
+    #[doc = "body: typing.List[Atom]"]
+    #[pyo3(get, set)]
+    pub body: VecWrap<Atom>,
+}
 
 #[pymethods]
 impl Rule {
     #[new]
-    fn new(head: VecWrap<Atom>,body: VecWrap<Atom>,) -> Self {
-        Rule {
-                head,
-                body,
-        }
+    fn new(head: VecWrap<Atom>, body: VecWrap<Atom>) -> Self {
+        Rule { head, body }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "head".to_string(),
-            "body".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("head".to_string(), "body".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
             "head" => self.head.clone().into_pyobject(py).map(Bound::into_any),
             "body" => self.body.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -19680,12 +21003,15 @@ impl Rule {
             "head" => {
                 self.head = value.extract()?;
                 Ok(())
-            },
+            }
             "body" => {
                 self.body = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -19699,9 +21025,10 @@ impl Rule {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::Rule<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::Rule<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -19737,7 +21064,6 @@ impl From<&horned_owl::model::Rule<ArcStr>> for Rule {
     }
 }
 
-
 impl From<&Rule> for horned_owl::model::Rule<ArcStr> {
     fn from(value: &Rule) -> Self {
         horned_owl::model::Rule::<ArcStr> {
@@ -19746,8 +21072,6 @@ impl From<&Rule> for horned_owl::model::Rule<ArcStr> {
         }
     }
 }
-
-
 
 /**************** Base implementations for Rule ****************/
 impl FromCompatible<horned_owl::model::Rule<ArcStr>> for Rule {
@@ -19879,148 +21203,146 @@ impl FromCompatible<&Vec<horned_owl::model::Rule<ArcStr>>> for VecWrap<Rule> {
 }
 #[derive(Debug, FromPyObject, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub enum Component {
-    
-        #[pyo3(transparent)]
-        OntologyID (OntologyID),
-    
-        #[pyo3(transparent)]
-        DocIRI (DocIRI),
-    
-        #[pyo3(transparent)]
-        OntologyAnnotation (OntologyAnnotation),
-    
-        #[pyo3(transparent)]
-        Import (Import),
-    
-        #[pyo3(transparent)]
-        DeclareClass (DeclareClass),
-    
-        #[pyo3(transparent)]
-        DeclareObjectProperty (DeclareObjectProperty),
-    
-        #[pyo3(transparent)]
-        DeclareAnnotationProperty (DeclareAnnotationProperty),
-    
-        #[pyo3(transparent)]
-        DeclareDataProperty (DeclareDataProperty),
-    
-        #[pyo3(transparent)]
-        DeclareNamedIndividual (DeclareNamedIndividual),
-    
-        #[pyo3(transparent)]
-        DeclareDatatype (DeclareDatatype),
-    
-        #[pyo3(transparent)]
-        SubClassOf (SubClassOf),
-    
-        #[pyo3(transparent)]
-        EquivalentClasses (EquivalentClasses),
-    
-        #[pyo3(transparent)]
-        DisjointClasses (DisjointClasses),
-    
-        #[pyo3(transparent)]
-        DisjointUnion (DisjointUnion),
-    
-        #[pyo3(transparent)]
-        SubObjectPropertyOf (SubObjectPropertyOf),
-    
-        #[pyo3(transparent)]
-        EquivalentObjectProperties (EquivalentObjectProperties),
-    
-        #[pyo3(transparent)]
-        DisjointObjectProperties (DisjointObjectProperties),
-    
-        #[pyo3(transparent)]
-        InverseObjectProperties (InverseObjectProperties),
-    
-        #[pyo3(transparent)]
-        ObjectPropertyDomain (ObjectPropertyDomain),
-    
-        #[pyo3(transparent)]
-        ObjectPropertyRange (ObjectPropertyRange),
-    
-        #[pyo3(transparent)]
-        FunctionalObjectProperty (FunctionalObjectProperty),
-    
-        #[pyo3(transparent)]
-        InverseFunctionalObjectProperty (InverseFunctionalObjectProperty),
-    
-        #[pyo3(transparent)]
-        ReflexiveObjectProperty (ReflexiveObjectProperty),
-    
-        #[pyo3(transparent)]
-        IrreflexiveObjectProperty (IrreflexiveObjectProperty),
-    
-        #[pyo3(transparent)]
-        SymmetricObjectProperty (SymmetricObjectProperty),
-    
-        #[pyo3(transparent)]
-        AsymmetricObjectProperty (AsymmetricObjectProperty),
-    
-        #[pyo3(transparent)]
-        TransitiveObjectProperty (TransitiveObjectProperty),
-    
-        #[pyo3(transparent)]
-        SubDataPropertyOf (SubDataPropertyOf),
-    
-        #[pyo3(transparent)]
-        EquivalentDataProperties (EquivalentDataProperties),
-    
-        #[pyo3(transparent)]
-        DisjointDataProperties (DisjointDataProperties),
-    
-        #[pyo3(transparent)]
-        DataPropertyDomain (DataPropertyDomain),
-    
-        #[pyo3(transparent)]
-        DataPropertyRange (DataPropertyRange),
-    
-        #[pyo3(transparent)]
-        FunctionalDataProperty (FunctionalDataProperty),
-    
-        #[pyo3(transparent)]
-        DatatypeDefinition (DatatypeDefinition),
-    
-        #[pyo3(transparent)]
-        HasKey (HasKey),
-    
-        #[pyo3(transparent)]
-        SameIndividual (SameIndividual),
-    
-        #[pyo3(transparent)]
-        DifferentIndividuals (DifferentIndividuals),
-    
-        #[pyo3(transparent)]
-        ClassAssertion (ClassAssertion),
-    
-        #[pyo3(transparent)]
-        ObjectPropertyAssertion (ObjectPropertyAssertion),
-    
-        #[pyo3(transparent)]
-        NegativeObjectPropertyAssertion (NegativeObjectPropertyAssertion),
-    
-        #[pyo3(transparent)]
-        DataPropertyAssertion (DataPropertyAssertion),
-    
-        #[pyo3(transparent)]
-        NegativeDataPropertyAssertion (NegativeDataPropertyAssertion),
-    
-        #[pyo3(transparent)]
-        AnnotationAssertion (AnnotationAssertion),
-    
-        #[pyo3(transparent)]
-        SubAnnotationPropertyOf (SubAnnotationPropertyOf),
-    
-        #[pyo3(transparent)]
-        AnnotationPropertyDomain (AnnotationPropertyDomain),
-    
-        #[pyo3(transparent)]
-        AnnotationPropertyRange (AnnotationPropertyRange),
-    
-        #[pyo3(transparent)]
-        Rule (Rule),
-    
+    #[pyo3(transparent)]
+    OntologyID(OntologyID),
+
+    #[pyo3(transparent)]
+    DocIRI(DocIRI),
+
+    #[pyo3(transparent)]
+    OntologyAnnotation(OntologyAnnotation),
+
+    #[pyo3(transparent)]
+    Import(Import),
+
+    #[pyo3(transparent)]
+    DeclareClass(DeclareClass),
+
+    #[pyo3(transparent)]
+    DeclareObjectProperty(DeclareObjectProperty),
+
+    #[pyo3(transparent)]
+    DeclareAnnotationProperty(DeclareAnnotationProperty),
+
+    #[pyo3(transparent)]
+    DeclareDataProperty(DeclareDataProperty),
+
+    #[pyo3(transparent)]
+    DeclareNamedIndividual(DeclareNamedIndividual),
+
+    #[pyo3(transparent)]
+    DeclareDatatype(DeclareDatatype),
+
+    #[pyo3(transparent)]
+    SubClassOf(SubClassOf),
+
+    #[pyo3(transparent)]
+    EquivalentClasses(EquivalentClasses),
+
+    #[pyo3(transparent)]
+    DisjointClasses(DisjointClasses),
+
+    #[pyo3(transparent)]
+    DisjointUnion(DisjointUnion),
+
+    #[pyo3(transparent)]
+    SubObjectPropertyOf(SubObjectPropertyOf),
+
+    #[pyo3(transparent)]
+    EquivalentObjectProperties(EquivalentObjectProperties),
+
+    #[pyo3(transparent)]
+    DisjointObjectProperties(DisjointObjectProperties),
+
+    #[pyo3(transparent)]
+    InverseObjectProperties(InverseObjectProperties),
+
+    #[pyo3(transparent)]
+    ObjectPropertyDomain(ObjectPropertyDomain),
+
+    #[pyo3(transparent)]
+    ObjectPropertyRange(ObjectPropertyRange),
+
+    #[pyo3(transparent)]
+    FunctionalObjectProperty(FunctionalObjectProperty),
+
+    #[pyo3(transparent)]
+    InverseFunctionalObjectProperty(InverseFunctionalObjectProperty),
+
+    #[pyo3(transparent)]
+    ReflexiveObjectProperty(ReflexiveObjectProperty),
+
+    #[pyo3(transparent)]
+    IrreflexiveObjectProperty(IrreflexiveObjectProperty),
+
+    #[pyo3(transparent)]
+    SymmetricObjectProperty(SymmetricObjectProperty),
+
+    #[pyo3(transparent)]
+    AsymmetricObjectProperty(AsymmetricObjectProperty),
+
+    #[pyo3(transparent)]
+    TransitiveObjectProperty(TransitiveObjectProperty),
+
+    #[pyo3(transparent)]
+    SubDataPropertyOf(SubDataPropertyOf),
+
+    #[pyo3(transparent)]
+    EquivalentDataProperties(EquivalentDataProperties),
+
+    #[pyo3(transparent)]
+    DisjointDataProperties(DisjointDataProperties),
+
+    #[pyo3(transparent)]
+    DataPropertyDomain(DataPropertyDomain),
+
+    #[pyo3(transparent)]
+    DataPropertyRange(DataPropertyRange),
+
+    #[pyo3(transparent)]
+    FunctionalDataProperty(FunctionalDataProperty),
+
+    #[pyo3(transparent)]
+    DatatypeDefinition(DatatypeDefinition),
+
+    #[pyo3(transparent)]
+    HasKey(HasKey),
+
+    #[pyo3(transparent)]
+    SameIndividual(SameIndividual),
+
+    #[pyo3(transparent)]
+    DifferentIndividuals(DifferentIndividuals),
+
+    #[pyo3(transparent)]
+    ClassAssertion(ClassAssertion),
+
+    #[pyo3(transparent)]
+    ObjectPropertyAssertion(ObjectPropertyAssertion),
+
+    #[pyo3(transparent)]
+    NegativeObjectPropertyAssertion(NegativeObjectPropertyAssertion),
+
+    #[pyo3(transparent)]
+    DataPropertyAssertion(DataPropertyAssertion),
+
+    #[pyo3(transparent)]
+    NegativeDataPropertyAssertion(NegativeDataPropertyAssertion),
+
+    #[pyo3(transparent)]
+    AnnotationAssertion(AnnotationAssertion),
+
+    #[pyo3(transparent)]
+    SubAnnotationPropertyOf(SubAnnotationPropertyOf),
+
+    #[pyo3(transparent)]
+    AnnotationPropertyDomain(AnnotationPropertyDomain),
+
+    #[pyo3(transparent)]
+    AnnotationPropertyRange(AnnotationPropertyRange),
+
+    #[pyo3(transparent)]
+    Rule(Rule),
 }
 
 impl<'py> IntoPyObject<'py> for Component {
@@ -20030,101 +21352,141 @@ impl<'py> IntoPyObject<'py> for Component {
 
     fn into_pyobject(self, py: Python<'py>) -> Result<Self::Output, Self::Error> {
         match self {
-        
             Component::OntologyID(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DocIRI(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::OntologyAnnotation(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::Import(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DeclareClass(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DeclareObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::DeclareAnnotationProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::DeclareAnnotationProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::DeclareDataProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::DeclareNamedIndividual(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::DeclareNamedIndividual(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::DeclareDatatype(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::SubClassOf(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::EquivalentClasses(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DisjointClasses(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DisjointUnion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::SubObjectPropertyOf(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::EquivalentObjectProperties(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::DisjointObjectProperties(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::InverseObjectProperties(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::EquivalentObjectProperties(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::DisjointObjectProperties(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::InverseObjectProperties(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::ObjectPropertyDomain(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::ObjectPropertyRange(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::FunctionalObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::InverseFunctionalObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::ReflexiveObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::IrreflexiveObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::SymmetricObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::AsymmetricObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::TransitiveObjectProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::FunctionalObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::InverseFunctionalObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::ReflexiveObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::IrreflexiveObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::SymmetricObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::AsymmetricObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::TransitiveObjectProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::SubDataPropertyOf(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::EquivalentDataProperties(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::DisjointDataProperties(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::EquivalentDataProperties(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::DisjointDataProperties(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::DataPropertyDomain(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DataPropertyRange(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::FunctionalDataProperty(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::FunctionalDataProperty(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::DatatypeDefinition(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::HasKey(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::SameIndividual(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::DifferentIndividuals(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
             Component::ClassAssertion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::ObjectPropertyAssertion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::NegativeObjectPropertyAssertion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::ObjectPropertyAssertion(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::NegativeObjectPropertyAssertion(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::DataPropertyAssertion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::NegativeDataPropertyAssertion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::NegativeDataPropertyAssertion(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::AnnotationAssertion(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::SubAnnotationPropertyOf(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::AnnotationPropertyDomain(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
-            Component::AnnotationPropertyRange(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
+
+            Component::SubAnnotationPropertyOf(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::AnnotationPropertyDomain(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
+            Component::AnnotationPropertyRange(inner) => {
+                inner.into_pyobject(py).map(Bound::into_any)
+            }
+
             Component::Rule(inner) => inner.into_pyobject(py).map(Bound::into_any),
-        
         }
     }
 }
@@ -20132,216 +21494,372 @@ impl<'py> IntoPyObject<'py> for Component {
 impl From<&Component> for horned_owl::model::Component<ArcStr> {
     fn from(value: &Component) -> Self {
         match value {
-        
             Component::OntologyID(inner) => horned_owl::model::Component::OntologyID(inner.into()),
-        
+
             Component::DocIRI(inner) => horned_owl::model::Component::DocIRI(inner.into()),
-        
-            Component::OntologyAnnotation(inner) => horned_owl::model::Component::OntologyAnnotation(inner.into()),
-        
+
+            Component::OntologyAnnotation(inner) => {
+                horned_owl::model::Component::OntologyAnnotation(inner.into())
+            }
+
             Component::Import(inner) => horned_owl::model::Component::Import(inner.into()),
-        
-            Component::DeclareClass(inner) => horned_owl::model::Component::DeclareClass(inner.into()),
-        
-            Component::DeclareObjectProperty(inner) => horned_owl::model::Component::DeclareObjectProperty(inner.into()),
-        
-            Component::DeclareAnnotationProperty(inner) => horned_owl::model::Component::DeclareAnnotationProperty(inner.into()),
-        
-            Component::DeclareDataProperty(inner) => horned_owl::model::Component::DeclareDataProperty(inner.into()),
-        
-            Component::DeclareNamedIndividual(inner) => horned_owl::model::Component::DeclareNamedIndividual(inner.into()),
-        
-            Component::DeclareDatatype(inner) => horned_owl::model::Component::DeclareDatatype(inner.into()),
-        
+
+            Component::DeclareClass(inner) => {
+                horned_owl::model::Component::DeclareClass(inner.into())
+            }
+
+            Component::DeclareObjectProperty(inner) => {
+                horned_owl::model::Component::DeclareObjectProperty(inner.into())
+            }
+
+            Component::DeclareAnnotationProperty(inner) => {
+                horned_owl::model::Component::DeclareAnnotationProperty(inner.into())
+            }
+
+            Component::DeclareDataProperty(inner) => {
+                horned_owl::model::Component::DeclareDataProperty(inner.into())
+            }
+
+            Component::DeclareNamedIndividual(inner) => {
+                horned_owl::model::Component::DeclareNamedIndividual(inner.into())
+            }
+
+            Component::DeclareDatatype(inner) => {
+                horned_owl::model::Component::DeclareDatatype(inner.into())
+            }
+
             Component::SubClassOf(inner) => horned_owl::model::Component::SubClassOf(inner.into()),
-        
-            Component::EquivalentClasses(inner) => horned_owl::model::Component::EquivalentClasses(inner.into()),
-        
-            Component::DisjointClasses(inner) => horned_owl::model::Component::DisjointClasses(inner.into()),
-        
-            Component::DisjointUnion(inner) => horned_owl::model::Component::DisjointUnion(inner.into()),
-        
-            Component::SubObjectPropertyOf(inner) => horned_owl::model::Component::SubObjectPropertyOf(inner.into()),
-        
-            Component::EquivalentObjectProperties(inner) => horned_owl::model::Component::EquivalentObjectProperties(inner.into()),
-        
-            Component::DisjointObjectProperties(inner) => horned_owl::model::Component::DisjointObjectProperties(inner.into()),
-        
-            Component::InverseObjectProperties(inner) => horned_owl::model::Component::InverseObjectProperties(inner.into()),
-        
-            Component::ObjectPropertyDomain(inner) => horned_owl::model::Component::ObjectPropertyDomain(inner.into()),
-        
-            Component::ObjectPropertyRange(inner) => horned_owl::model::Component::ObjectPropertyRange(inner.into()),
-        
-            Component::FunctionalObjectProperty(inner) => horned_owl::model::Component::FunctionalObjectProperty(inner.into()),
-        
-            Component::InverseFunctionalObjectProperty(inner) => horned_owl::model::Component::InverseFunctionalObjectProperty(inner.into()),
-        
-            Component::ReflexiveObjectProperty(inner) => horned_owl::model::Component::ReflexiveObjectProperty(inner.into()),
-        
-            Component::IrreflexiveObjectProperty(inner) => horned_owl::model::Component::IrreflexiveObjectProperty(inner.into()),
-        
-            Component::SymmetricObjectProperty(inner) => horned_owl::model::Component::SymmetricObjectProperty(inner.into()),
-        
-            Component::AsymmetricObjectProperty(inner) => horned_owl::model::Component::AsymmetricObjectProperty(inner.into()),
-        
-            Component::TransitiveObjectProperty(inner) => horned_owl::model::Component::TransitiveObjectProperty(inner.into()),
-        
-            Component::SubDataPropertyOf(inner) => horned_owl::model::Component::SubDataPropertyOf(inner.into()),
-        
-            Component::EquivalentDataProperties(inner) => horned_owl::model::Component::EquivalentDataProperties(inner.into()),
-        
-            Component::DisjointDataProperties(inner) => horned_owl::model::Component::DisjointDataProperties(inner.into()),
-        
-            Component::DataPropertyDomain(inner) => horned_owl::model::Component::DataPropertyDomain(inner.into()),
-        
-            Component::DataPropertyRange(inner) => horned_owl::model::Component::DataPropertyRange(inner.into()),
-        
-            Component::FunctionalDataProperty(inner) => horned_owl::model::Component::FunctionalDataProperty(inner.into()),
-        
-            Component::DatatypeDefinition(inner) => horned_owl::model::Component::DatatypeDefinition(inner.into()),
-        
+
+            Component::EquivalentClasses(inner) => {
+                horned_owl::model::Component::EquivalentClasses(inner.into())
+            }
+
+            Component::DisjointClasses(inner) => {
+                horned_owl::model::Component::DisjointClasses(inner.into())
+            }
+
+            Component::DisjointUnion(inner) => {
+                horned_owl::model::Component::DisjointUnion(inner.into())
+            }
+
+            Component::SubObjectPropertyOf(inner) => {
+                horned_owl::model::Component::SubObjectPropertyOf(inner.into())
+            }
+
+            Component::EquivalentObjectProperties(inner) => {
+                horned_owl::model::Component::EquivalentObjectProperties(inner.into())
+            }
+
+            Component::DisjointObjectProperties(inner) => {
+                horned_owl::model::Component::DisjointObjectProperties(inner.into())
+            }
+
+            Component::InverseObjectProperties(inner) => {
+                horned_owl::model::Component::InverseObjectProperties(inner.into())
+            }
+
+            Component::ObjectPropertyDomain(inner) => {
+                horned_owl::model::Component::ObjectPropertyDomain(inner.into())
+            }
+
+            Component::ObjectPropertyRange(inner) => {
+                horned_owl::model::Component::ObjectPropertyRange(inner.into())
+            }
+
+            Component::FunctionalObjectProperty(inner) => {
+                horned_owl::model::Component::FunctionalObjectProperty(inner.into())
+            }
+
+            Component::InverseFunctionalObjectProperty(inner) => {
+                horned_owl::model::Component::InverseFunctionalObjectProperty(inner.into())
+            }
+
+            Component::ReflexiveObjectProperty(inner) => {
+                horned_owl::model::Component::ReflexiveObjectProperty(inner.into())
+            }
+
+            Component::IrreflexiveObjectProperty(inner) => {
+                horned_owl::model::Component::IrreflexiveObjectProperty(inner.into())
+            }
+
+            Component::SymmetricObjectProperty(inner) => {
+                horned_owl::model::Component::SymmetricObjectProperty(inner.into())
+            }
+
+            Component::AsymmetricObjectProperty(inner) => {
+                horned_owl::model::Component::AsymmetricObjectProperty(inner.into())
+            }
+
+            Component::TransitiveObjectProperty(inner) => {
+                horned_owl::model::Component::TransitiveObjectProperty(inner.into())
+            }
+
+            Component::SubDataPropertyOf(inner) => {
+                horned_owl::model::Component::SubDataPropertyOf(inner.into())
+            }
+
+            Component::EquivalentDataProperties(inner) => {
+                horned_owl::model::Component::EquivalentDataProperties(inner.into())
+            }
+
+            Component::DisjointDataProperties(inner) => {
+                horned_owl::model::Component::DisjointDataProperties(inner.into())
+            }
+
+            Component::DataPropertyDomain(inner) => {
+                horned_owl::model::Component::DataPropertyDomain(inner.into())
+            }
+
+            Component::DataPropertyRange(inner) => {
+                horned_owl::model::Component::DataPropertyRange(inner.into())
+            }
+
+            Component::FunctionalDataProperty(inner) => {
+                horned_owl::model::Component::FunctionalDataProperty(inner.into())
+            }
+
+            Component::DatatypeDefinition(inner) => {
+                horned_owl::model::Component::DatatypeDefinition(inner.into())
+            }
+
             Component::HasKey(inner) => horned_owl::model::Component::HasKey(inner.into()),
-        
-            Component::SameIndividual(inner) => horned_owl::model::Component::SameIndividual(inner.into()),
-        
-            Component::DifferentIndividuals(inner) => horned_owl::model::Component::DifferentIndividuals(inner.into()),
-        
-            Component::ClassAssertion(inner) => horned_owl::model::Component::ClassAssertion(inner.into()),
-        
-            Component::ObjectPropertyAssertion(inner) => horned_owl::model::Component::ObjectPropertyAssertion(inner.into()),
-        
-            Component::NegativeObjectPropertyAssertion(inner) => horned_owl::model::Component::NegativeObjectPropertyAssertion(inner.into()),
-        
-            Component::DataPropertyAssertion(inner) => horned_owl::model::Component::DataPropertyAssertion(inner.into()),
-        
-            Component::NegativeDataPropertyAssertion(inner) => horned_owl::model::Component::NegativeDataPropertyAssertion(inner.into()),
-        
-            Component::AnnotationAssertion(inner) => horned_owl::model::Component::AnnotationAssertion(inner.into()),
-        
-            Component::SubAnnotationPropertyOf(inner) => horned_owl::model::Component::SubAnnotationPropertyOf(inner.into()),
-        
-            Component::AnnotationPropertyDomain(inner) => horned_owl::model::Component::AnnotationPropertyDomain(inner.into()),
-        
-            Component::AnnotationPropertyRange(inner) => horned_owl::model::Component::AnnotationPropertyRange(inner.into()),
-        
+
+            Component::SameIndividual(inner) => {
+                horned_owl::model::Component::SameIndividual(inner.into())
+            }
+
+            Component::DifferentIndividuals(inner) => {
+                horned_owl::model::Component::DifferentIndividuals(inner.into())
+            }
+
+            Component::ClassAssertion(inner) => {
+                horned_owl::model::Component::ClassAssertion(inner.into())
+            }
+
+            Component::ObjectPropertyAssertion(inner) => {
+                horned_owl::model::Component::ObjectPropertyAssertion(inner.into())
+            }
+
+            Component::NegativeObjectPropertyAssertion(inner) => {
+                horned_owl::model::Component::NegativeObjectPropertyAssertion(inner.into())
+            }
+
+            Component::DataPropertyAssertion(inner) => {
+                horned_owl::model::Component::DataPropertyAssertion(inner.into())
+            }
+
+            Component::NegativeDataPropertyAssertion(inner) => {
+                horned_owl::model::Component::NegativeDataPropertyAssertion(inner.into())
+            }
+
+            Component::AnnotationAssertion(inner) => {
+                horned_owl::model::Component::AnnotationAssertion(inner.into())
+            }
+
+            Component::SubAnnotationPropertyOf(inner) => {
+                horned_owl::model::Component::SubAnnotationPropertyOf(inner.into())
+            }
+
+            Component::AnnotationPropertyDomain(inner) => {
+                horned_owl::model::Component::AnnotationPropertyDomain(inner.into())
+            }
+
+            Component::AnnotationPropertyRange(inner) => {
+                horned_owl::model::Component::AnnotationPropertyRange(inner.into())
+            }
+
             Component::Rule(inner) => horned_owl::model::Component::Rule(inner.into()),
-        
         }
     }
 }
 
 impl From<&horned_owl::model::Component<ArcStr>> for Component {
-
     fn from(value: &horned_owl::model::Component<ArcStr>) -> Self {
         match value {
-        
             horned_owl::model::Component::OntologyID(inner) => Component::OntologyID(inner.into()),
-        
+
             horned_owl::model::Component::DocIRI(inner) => Component::DocIRI(inner.into()),
-        
-            horned_owl::model::Component::OntologyAnnotation(inner) => Component::OntologyAnnotation(inner.into()),
-        
+
+            horned_owl::model::Component::OntologyAnnotation(inner) => {
+                Component::OntologyAnnotation(inner.into())
+            }
+
             horned_owl::model::Component::Import(inner) => Component::Import(inner.into()),
-        
-            horned_owl::model::Component::DeclareClass(inner) => Component::DeclareClass(inner.into()),
-        
-            horned_owl::model::Component::DeclareObjectProperty(inner) => Component::DeclareObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::DeclareAnnotationProperty(inner) => Component::DeclareAnnotationProperty(inner.into()),
-        
-            horned_owl::model::Component::DeclareDataProperty(inner) => Component::DeclareDataProperty(inner.into()),
-        
-            horned_owl::model::Component::DeclareNamedIndividual(inner) => Component::DeclareNamedIndividual(inner.into()),
-        
-            horned_owl::model::Component::DeclareDatatype(inner) => Component::DeclareDatatype(inner.into()),
-        
+
+            horned_owl::model::Component::DeclareClass(inner) => {
+                Component::DeclareClass(inner.into())
+            }
+
+            horned_owl::model::Component::DeclareObjectProperty(inner) => {
+                Component::DeclareObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::DeclareAnnotationProperty(inner) => {
+                Component::DeclareAnnotationProperty(inner.into())
+            }
+
+            horned_owl::model::Component::DeclareDataProperty(inner) => {
+                Component::DeclareDataProperty(inner.into())
+            }
+
+            horned_owl::model::Component::DeclareNamedIndividual(inner) => {
+                Component::DeclareNamedIndividual(inner.into())
+            }
+
+            horned_owl::model::Component::DeclareDatatype(inner) => {
+                Component::DeclareDatatype(inner.into())
+            }
+
             horned_owl::model::Component::SubClassOf(inner) => Component::SubClassOf(inner.into()),
-        
-            horned_owl::model::Component::EquivalentClasses(inner) => Component::EquivalentClasses(inner.into()),
-        
-            horned_owl::model::Component::DisjointClasses(inner) => Component::DisjointClasses(inner.into()),
-        
-            horned_owl::model::Component::DisjointUnion(inner) => Component::DisjointUnion(inner.into()),
-        
-            horned_owl::model::Component::SubObjectPropertyOf(inner) => Component::SubObjectPropertyOf(inner.into()),
-        
-            horned_owl::model::Component::EquivalentObjectProperties(inner) => Component::EquivalentObjectProperties(inner.into()),
-        
-            horned_owl::model::Component::DisjointObjectProperties(inner) => Component::DisjointObjectProperties(inner.into()),
-        
-            horned_owl::model::Component::InverseObjectProperties(inner) => Component::InverseObjectProperties(inner.into()),
-        
-            horned_owl::model::Component::ObjectPropertyDomain(inner) => Component::ObjectPropertyDomain(inner.into()),
-        
-            horned_owl::model::Component::ObjectPropertyRange(inner) => Component::ObjectPropertyRange(inner.into()),
-        
-            horned_owl::model::Component::FunctionalObjectProperty(inner) => Component::FunctionalObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::InverseFunctionalObjectProperty(inner) => Component::InverseFunctionalObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::ReflexiveObjectProperty(inner) => Component::ReflexiveObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::IrreflexiveObjectProperty(inner) => Component::IrreflexiveObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::SymmetricObjectProperty(inner) => Component::SymmetricObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::AsymmetricObjectProperty(inner) => Component::AsymmetricObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::TransitiveObjectProperty(inner) => Component::TransitiveObjectProperty(inner.into()),
-        
-            horned_owl::model::Component::SubDataPropertyOf(inner) => Component::SubDataPropertyOf(inner.into()),
-        
-            horned_owl::model::Component::EquivalentDataProperties(inner) => Component::EquivalentDataProperties(inner.into()),
-        
-            horned_owl::model::Component::DisjointDataProperties(inner) => Component::DisjointDataProperties(inner.into()),
-        
-            horned_owl::model::Component::DataPropertyDomain(inner) => Component::DataPropertyDomain(inner.into()),
-        
-            horned_owl::model::Component::DataPropertyRange(inner) => Component::DataPropertyRange(inner.into()),
-        
-            horned_owl::model::Component::FunctionalDataProperty(inner) => Component::FunctionalDataProperty(inner.into()),
-        
-            horned_owl::model::Component::DatatypeDefinition(inner) => Component::DatatypeDefinition(inner.into()),
-        
+
+            horned_owl::model::Component::EquivalentClasses(inner) => {
+                Component::EquivalentClasses(inner.into())
+            }
+
+            horned_owl::model::Component::DisjointClasses(inner) => {
+                Component::DisjointClasses(inner.into())
+            }
+
+            horned_owl::model::Component::DisjointUnion(inner) => {
+                Component::DisjointUnion(inner.into())
+            }
+
+            horned_owl::model::Component::SubObjectPropertyOf(inner) => {
+                Component::SubObjectPropertyOf(inner.into())
+            }
+
+            horned_owl::model::Component::EquivalentObjectProperties(inner) => {
+                Component::EquivalentObjectProperties(inner.into())
+            }
+
+            horned_owl::model::Component::DisjointObjectProperties(inner) => {
+                Component::DisjointObjectProperties(inner.into())
+            }
+
+            horned_owl::model::Component::InverseObjectProperties(inner) => {
+                Component::InverseObjectProperties(inner.into())
+            }
+
+            horned_owl::model::Component::ObjectPropertyDomain(inner) => {
+                Component::ObjectPropertyDomain(inner.into())
+            }
+
+            horned_owl::model::Component::ObjectPropertyRange(inner) => {
+                Component::ObjectPropertyRange(inner.into())
+            }
+
+            horned_owl::model::Component::FunctionalObjectProperty(inner) => {
+                Component::FunctionalObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::InverseFunctionalObjectProperty(inner) => {
+                Component::InverseFunctionalObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::ReflexiveObjectProperty(inner) => {
+                Component::ReflexiveObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::IrreflexiveObjectProperty(inner) => {
+                Component::IrreflexiveObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::SymmetricObjectProperty(inner) => {
+                Component::SymmetricObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::AsymmetricObjectProperty(inner) => {
+                Component::AsymmetricObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::TransitiveObjectProperty(inner) => {
+                Component::TransitiveObjectProperty(inner.into())
+            }
+
+            horned_owl::model::Component::SubDataPropertyOf(inner) => {
+                Component::SubDataPropertyOf(inner.into())
+            }
+
+            horned_owl::model::Component::EquivalentDataProperties(inner) => {
+                Component::EquivalentDataProperties(inner.into())
+            }
+
+            horned_owl::model::Component::DisjointDataProperties(inner) => {
+                Component::DisjointDataProperties(inner.into())
+            }
+
+            horned_owl::model::Component::DataPropertyDomain(inner) => {
+                Component::DataPropertyDomain(inner.into())
+            }
+
+            horned_owl::model::Component::DataPropertyRange(inner) => {
+                Component::DataPropertyRange(inner.into())
+            }
+
+            horned_owl::model::Component::FunctionalDataProperty(inner) => {
+                Component::FunctionalDataProperty(inner.into())
+            }
+
+            horned_owl::model::Component::DatatypeDefinition(inner) => {
+                Component::DatatypeDefinition(inner.into())
+            }
+
             horned_owl::model::Component::HasKey(inner) => Component::HasKey(inner.into()),
-        
-            horned_owl::model::Component::SameIndividual(inner) => Component::SameIndividual(inner.into()),
-        
-            horned_owl::model::Component::DifferentIndividuals(inner) => Component::DifferentIndividuals(inner.into()),
-        
-            horned_owl::model::Component::ClassAssertion(inner) => Component::ClassAssertion(inner.into()),
-        
-            horned_owl::model::Component::ObjectPropertyAssertion(inner) => Component::ObjectPropertyAssertion(inner.into()),
-        
-            horned_owl::model::Component::NegativeObjectPropertyAssertion(inner) => Component::NegativeObjectPropertyAssertion(inner.into()),
-        
-            horned_owl::model::Component::DataPropertyAssertion(inner) => Component::DataPropertyAssertion(inner.into()),
-        
-            horned_owl::model::Component::NegativeDataPropertyAssertion(inner) => Component::NegativeDataPropertyAssertion(inner.into()),
-        
-            horned_owl::model::Component::AnnotationAssertion(inner) => Component::AnnotationAssertion(inner.into()),
-        
-            horned_owl::model::Component::SubAnnotationPropertyOf(inner) => Component::SubAnnotationPropertyOf(inner.into()),
-        
-            horned_owl::model::Component::AnnotationPropertyDomain(inner) => Component::AnnotationPropertyDomain(inner.into()),
-        
-            horned_owl::model::Component::AnnotationPropertyRange(inner) => Component::AnnotationPropertyRange(inner.into()),
-        
+
+            horned_owl::model::Component::SameIndividual(inner) => {
+                Component::SameIndividual(inner.into())
+            }
+
+            horned_owl::model::Component::DifferentIndividuals(inner) => {
+                Component::DifferentIndividuals(inner.into())
+            }
+
+            horned_owl::model::Component::ClassAssertion(inner) => {
+                Component::ClassAssertion(inner.into())
+            }
+
+            horned_owl::model::Component::ObjectPropertyAssertion(inner) => {
+                Component::ObjectPropertyAssertion(inner.into())
+            }
+
+            horned_owl::model::Component::NegativeObjectPropertyAssertion(inner) => {
+                Component::NegativeObjectPropertyAssertion(inner.into())
+            }
+
+            horned_owl::model::Component::DataPropertyAssertion(inner) => {
+                Component::DataPropertyAssertion(inner.into())
+            }
+
+            horned_owl::model::Component::NegativeDataPropertyAssertion(inner) => {
+                Component::NegativeDataPropertyAssertion(inner.into())
+            }
+
+            horned_owl::model::Component::AnnotationAssertion(inner) => {
+                Component::AnnotationAssertion(inner.into())
+            }
+
+            horned_owl::model::Component::SubAnnotationPropertyOf(inner) => {
+                Component::SubAnnotationPropertyOf(inner.into())
+            }
+
+            horned_owl::model::Component::AnnotationPropertyDomain(inner) => {
+                Component::AnnotationPropertyDomain(inner.into())
+            }
+
+            horned_owl::model::Component::AnnotationPropertyRange(inner) => {
+                Component::AnnotationPropertyRange(inner.into())
+            }
+
             horned_owl::model::Component::Rule(inner) => Component::Rule(inner.into()),
-        
         }
     }
 }
-
 
 impl Component {
     pub fn py_def() -> String {
         "typing.Union[m.OntologyID,m.DocIRI,m.OntologyAnnotation,m.Import,m.DeclareClass,m.DeclareObjectProperty,m.DeclareAnnotationProperty,m.DeclareDataProperty,m.DeclareNamedIndividual,m.DeclareDatatype,m.SubClassOf,m.EquivalentClasses,m.DisjointClasses,m.DisjointUnion,m.SubObjectPropertyOf,m.EquivalentObjectProperties,m.DisjointObjectProperties,m.InverseObjectProperties,m.ObjectPropertyDomain,m.ObjectPropertyRange,m.FunctionalObjectProperty,m.InverseFunctionalObjectProperty,m.ReflexiveObjectProperty,m.IrreflexiveObjectProperty,m.SymmetricObjectProperty,m.AsymmetricObjectProperty,m.TransitiveObjectProperty,m.SubDataPropertyOf,m.EquivalentDataProperties,m.DisjointDataProperties,m.DataPropertyDomain,m.DataPropertyRange,m.FunctionalDataProperty,m.DatatypeDefinition,m.HasKey,m.SameIndividual,m.DifferentIndividuals,m.ClassAssertion,m.ObjectPropertyAssertion,m.NegativeObjectPropertyAssertion,m.DataPropertyAssertion,m.NegativeDataPropertyAssertion,m.AnnotationAssertion,m.SubAnnotationPropertyOf,m.AnnotationPropertyDomain,m.AnnotationPropertyRange,m.Rule,]".into()
     }
 }
-
-
 
 /**************** Base implementations for Component ****************/
 impl FromCompatible<horned_owl::model::Component<ArcStr>> for Component {
@@ -20475,41 +21993,42 @@ impl FromCompatible<&Vec<horned_owl::model::Component<ArcStr>>> for VecWrap<Comp
     "\n\n",
     doc!(AnnotatedComponent)
 )]
-#[pyclass(module="pyhornedowl.model",mapping,from_py_object)]
+#[pyclass(module = "pyhornedowl.model", mapping, from_py_object)]
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct AnnotatedComponent {
-        #[doc="component: Component"]
-        #[pyo3(get,set)]
-        pub component: Component,
-    
-        #[doc="ann: typing.Set[Annotation]"]
-        #[pyo3(get,set)]
-        pub ann: BTreeSetWrap<Annotation>,
-    }
+    #[doc = "component: Component"]
+    #[pyo3(get, set)]
+    pub component: Component,
+
+    #[doc = "ann: typing.Set[Annotation]"]
+    #[pyo3(get, set)]
+    pub ann: BTreeSetWrap<Annotation>,
+}
 
 #[pymethods]
 impl AnnotatedComponent {
     #[new]
-    fn new(component: Component,ann: BTreeSetWrap<Annotation>,) -> Self {
-        AnnotatedComponent {
-                component,
-                ann,
-        }
+    fn new(component: Component, ann: BTreeSetWrap<Annotation>) -> Self {
+        AnnotatedComponent { component, ann }
     }
 
     #[classattr]
-    fn __match_args__() -> PyResult<(String, String,)> {
-        Ok((
-            "component".to_string(),
-            "ann".to_string(),
-        ))
+    fn __match_args__() -> PyResult<(String, String)> {
+        Ok(("component".to_string(), "ann".to_string()))
     }
 
     fn __getitem__<'py>(&self, py: Python<'py>, name: &str) -> PyResult<Bound<'py, PyAny>> {
         match name {
-            "component" => self.component.clone().into_pyobject(py).map(Bound::into_any),
+            "component" => self
+                .component
+                .clone()
+                .into_pyobject(py)
+                .map(Bound::into_any),
             "ann" => self.ann.clone().into_pyobject(py).map(Bound::into_any),
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -20518,12 +22037,15 @@ impl AnnotatedComponent {
             "component" => {
                 self.component = value.extract()?;
                 Ok(())
-            },
+            }
             "ann" => {
                 self.ann = value.extract()?;
                 Ok(())
-            },
-            &_ => Err(PyKeyError::new_err(format!("The field '{}' does not exist.", name)))
+            }
+            &_ => Err(PyKeyError::new_err(format!(
+                "The field '{}' does not exist.",
+                name
+            ))),
         }
     }
 
@@ -20537,9 +22059,10 @@ impl AnnotatedComponent {
         self == other
     }
     fn __str__(&self) -> String {
-        Into::<horned_owl::model::AnnotatedComponent<ArcStr>>::into(self.clone()).as_functional().to_string()
+        Into::<horned_owl::model::AnnotatedComponent<ArcStr>>::into(self.clone())
+            .as_functional()
+            .to_string()
     }
-
 
     /// serialize(self, serialization = "ofn", prefix_mapping = None)
     ///
@@ -20574,7 +22097,6 @@ impl From<&horned_owl::model::AnnotatedComponent<ArcStr>> for AnnotatedComponent
     }
 }
 
-
 impl From<&AnnotatedComponent> for horned_owl::model::AnnotatedComponent<ArcStr> {
     fn from(value: &AnnotatedComponent) -> Self {
         horned_owl::model::AnnotatedComponent::<ArcStr> {
@@ -20583,8 +22105,6 @@ impl From<&AnnotatedComponent> for horned_owl::model::AnnotatedComponent<ArcStr>
         }
     }
 }
-
-
 
 /**************** Base implementations for AnnotatedComponent ****************/
 impl FromCompatible<horned_owl::model::AnnotatedComponent<ArcStr>> for AnnotatedComponent {
@@ -20674,42 +22194,58 @@ impl From<&Vec<horned_owl::model::AnnotatedComponent<ArcStr>>> for VecWrap<Annot
     }
 }
 
-impl FromCompatible<&BoxWrap<AnnotatedComponent>> for Box<horned_owl::model::AnnotatedComponent<ArcStr>> {
+impl FromCompatible<&BoxWrap<AnnotatedComponent>>
+    for Box<horned_owl::model::AnnotatedComponent<ArcStr>>
+{
     fn from_c(value: &BoxWrap<AnnotatedComponent>) -> Self {
         Box::<horned_owl::model::AnnotatedComponent<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Box<horned_owl::model::AnnotatedComponent<ArcStr>>> for BoxWrap<AnnotatedComponent> {
+impl FromCompatible<&Box<horned_owl::model::AnnotatedComponent<ArcStr>>>
+    for BoxWrap<AnnotatedComponent>
+{
     fn from_c(value: &Box<horned_owl::model::AnnotatedComponent<ArcStr>>) -> Self {
         BoxWrap::<AnnotatedComponent>::from(value)
     }
 }
-impl FromCompatible<BoxWrap<AnnotatedComponent>> for Box<horned_owl::model::AnnotatedComponent<ArcStr>> {
+impl FromCompatible<BoxWrap<AnnotatedComponent>>
+    for Box<horned_owl::model::AnnotatedComponent<ArcStr>>
+{
     fn from_c(value: BoxWrap<AnnotatedComponent>) -> Self {
         Box::<horned_owl::model::AnnotatedComponent<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Box<horned_owl::model::AnnotatedComponent<ArcStr>>> for BoxWrap<AnnotatedComponent> {
+impl FromCompatible<Box<horned_owl::model::AnnotatedComponent<ArcStr>>>
+    for BoxWrap<AnnotatedComponent>
+{
     fn from_c(value: Box<horned_owl::model::AnnotatedComponent<ArcStr>>) -> Self {
         BoxWrap::<AnnotatedComponent>::from(value)
     }
 }
-impl FromCompatible<VecWrap<AnnotatedComponent>> for Vec<horned_owl::model::AnnotatedComponent<ArcStr>> {
+impl FromCompatible<VecWrap<AnnotatedComponent>>
+    for Vec<horned_owl::model::AnnotatedComponent<ArcStr>>
+{
     fn from_c(value: VecWrap<AnnotatedComponent>) -> Self {
         Vec::<horned_owl::model::AnnotatedComponent<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<Vec<horned_owl::model::AnnotatedComponent<ArcStr>>> for VecWrap<AnnotatedComponent> {
+impl FromCompatible<Vec<horned_owl::model::AnnotatedComponent<ArcStr>>>
+    for VecWrap<AnnotatedComponent>
+{
     fn from_c(value: Vec<horned_owl::model::AnnotatedComponent<ArcStr>>) -> Self {
         VecWrap::<AnnotatedComponent>::from(value)
     }
 }
-impl FromCompatible<&VecWrap<AnnotatedComponent>> for Vec<horned_owl::model::AnnotatedComponent<ArcStr>> {
+impl FromCompatible<&VecWrap<AnnotatedComponent>>
+    for Vec<horned_owl::model::AnnotatedComponent<ArcStr>>
+{
     fn from_c(value: &VecWrap<AnnotatedComponent>) -> Self {
         Vec::<horned_owl::model::AnnotatedComponent<ArcStr>>::from(value)
     }
 }
-impl FromCompatible<&Vec<horned_owl::model::AnnotatedComponent<ArcStr>>> for VecWrap<AnnotatedComponent> {
+impl FromCompatible<&Vec<horned_owl::model::AnnotatedComponent<ArcStr>>>
+    for VecWrap<AnnotatedComponent>
+{
     fn from_c(value: &Vec<horned_owl::model::AnnotatedComponent<ArcStr>>) -> Self {
         VecWrap::<AnnotatedComponent>::from(value)
     }

--- a/src/ontology.rs
+++ b/src/ontology.rs
@@ -1255,7 +1255,7 @@ impl PyIndexedOntology {
             InputFormat::Rdf(f) => horned_owl::io::rdf::writer::write_to_rdf_format(
                 &mut file,
                 &amo,
-                f.unwrap_or(RdfFormat::RdfXml).file_extension()
+                f.unwrap_or(RdfFormat::RdfXml).file_extension(),
             ),
             InputFormat::OMN => {
                 horned_owl::io::omn::writer::write(&mut file, &amo, Some(&mapping.0))


### PR DESCRIPTION
Makes `cargo fmt --check` pass, and adds CI that keeps it passing along with the generated files being up to date.

Three commits, meant to be read in order — the first is bulk reformatting, the other two are small.

### 1. Format the generated model with rustfmt

`src/model_generated.rs` was ~1200 rustfmt hunks out of shape, which is why `cargo fmt --check` could not be used on the crate at all.

Fixing that in the templates is the wrong layer: how long an emitted line is depends on the name of the model class it is emitted for, so each emission site would need its own line-width rule. `scripts/build_model.py` formats its own output instead, the way codegen for any other language would, and the templates stay readable.

rustfmt is required rather than optional — silently emitting unformatted code would put the check back where it started. It ships with rustup's default toolchain. The edition is read from `Cargo.toml` so the two cannot drift.

The bulk of this PR is that one-time reformat. Re-running the generator afterwards is idempotent.

### 2. rustfmt the two hand-written stragglers

A collapsible closure in `open_ontology_from_string` and a missing trailing comma in `save_to_buf`. With these, the whole crate passes.

### 3. CI: formatting, and generated files up to date

Nothing verified that the checked-in generated files matched what the generators produce. #67 hit this: the `omn`/`obo` values had been hand-added to `pyhornedowl/__init__.pyi`, which `gen_pyi.py` writes from the `///` signature lines in the Rust sources, so `make pyi` would have silently reverted them. Review cannot catch it — the diff looks right either way.

The new job regenerates the model and the stubs, fails on any difference, and runs `cargo fmt --check`.

It invokes the generators directly rather than through the Makefile, for two reasons worth knowing:

- The `docs` target runs `scripts/build_doc.py`, which extracts rustdoc JSON from a local horned-owl checkout using a nightly toolchain. CI has neither, so `src/doc.rs` stays hand-regenerated and is not covered by this check.
- Going through make would also make this job depend on #70 — `make model` creates `.venv`, and the next target needing it then fails, because `.venv` is currently declared `.PHONY`.

### Verification

Against a fresh clone, both with and without a pre-existing `.venv`: `cargo fmt --check` passes, the regeneration steps run clean, and `git diff --exit-code` is empty. I also committed a hand-edit to a generated stub and confirmed the job fails on it.

`156 passed, 7 skipped, 1 xfailed`; `cargo test` 6 passed.

### Note

`.github/workflows/CI.yaml` carries a "generated by maturin, to update run `maturin generate-ci github`" header, but already has hand-added `build-docs` and `deploy` jobs, so I added this one the same way. If you would rather it lived in a separate workflow file, happy to move it.
